### PR TITLE
Add functions for ICA/PCA reconstruction

### DIFF
--- a/util/ICA_PCA_reconstruction_functions.R
+++ b/util/ICA_PCA_reconstruction_functions.R
@@ -128,14 +128,12 @@ EvaluatePCARecon <- function(train.dt, test.dt, no.comp = 50){
   # transpose mat for test data, to be used as "true.mat"
   test.dm.t <- ExpressionDataTableToMatrixT(test.dt)
   
-  
   # quantification: how well did we do at reconstruction?
   mase <- GetMASE(true.mat = test.dm.t, recon.mat = recon.test)
   names(mase) <- colnames(test.dm.t)
   
   # return reconstruction error and PCA output
   return(list("MASE" = mase, "PC" = pc))
-  
   
 }
 


### PR DESCRIPTION
I believe this already takes into account all of the comments from @gwaygenomics on PR #2. 

I have a wrapper function that will do ICA or PCA on lists of training data. If that would be helpful to include in the scope of this PR, let me know.
