### PR TITLE
Add script for plotting differential expression results

### DIFF
--- a/2A-plot_DE_results.R
+++ b/2A-plot_DE_results.R
@@ -82,15 +82,15 @@ PlotProportionDE <- function(fit.list, adjust.method = "BH", cutoff = 0.05) {
   
   # get topTables
   top.table.list <- 
-    lapply(fit.list, 
-           function(x) 
-             lapply(x, 
+    lapply(fit.list,  # for each level of % seq
+           function(x)   
+             lapply(x, # for each normalization method
                     function(y) GetAllGenesTopTable(y, adjust = adjust.method)))
   
   # how many genes are differentially expressed @ cutoff
   deg.count.count.list <- 
-    lapply(top.table.list, 
-           function(x) lapply(x, 
+    lapply(top.table.list,  # for each level of % seq
+           function(x) lapply(x,  # for each normalization method  
                               function(y) sum(y$adj.P.Val < cutoff)))
   # get DEG counts as data.frame
   deg.count.df <- reshape2::melt(deg.count.count.list)


### PR DESCRIPTION
Adding a script for plotting differential expression results - the output of `1A-detect_differentially_expressed_genes.R`. 

We are interested in how our 'RNA-seq titration' results (from various norm methods) compare to "silver standards." We define "silver standards" as the differentially expressed genes (DEGs) identified using standard pipelines (i.e., log-transformed array data [100% array data], RSEM RNA-seq data [termed 'untransformed', 100% RNA-seq data]) and calculate + plot the Jaccard similarity between our experimental DEGs and the silver standard sets.

Note, I fully expect some (most?) of these functions are going to get moved into `differential_expression_functions.R` and modified for use with some experiments looking at small sample sizes.