### PR TITLE
Add Kappa summary tables

### DIFF
--- a/3-plot_subtype_kappa.R
+++ b/3-plot_subtype_kappa.R
@@ -6,6 +6,7 @@
 
 source(file.path("util", "color_blind_friendly_palette.R"))
 
+`%>%` <- dplyr::`%>%`
 library(ggplot2)
 library(data.table)
 
@@ -77,3 +78,13 @@ for (cls in cls.methods) {
     theme(axis.text.x = element_text(angle = 45, vjust = 0.5)) 
   ggsave(plot.nm, plot = last_plot(), height = 3.5, width = 15)
 }
+
+# get summary data.frame + write to file
+summary.df <- 
+  kappa.master.df %>%
+    dplyr::group_by(Classifier, Normalization, Platform, Perc.seq) %>%
+    dplyr::summarise(Median = median(Kappa),
+                     Mean = mean(Kappa),
+                     SD = sd(Kappa))
+readr::write_tsv(summary.df, 
+                 file.path("results", "BRCA_train_3_models_summary_table.tsv"))

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -110,8 +110,7 @@ error.master.df$perc.seq <- factor(error.master.df$perc.seq,
                                    levels = seq(0, 100, by = 10))
 
 # get norm and reconstruction methods as factors 
-error.master.df$normalization <- as.factor(error.master.df$normalization)
-error.master.df$error.measure <- as.factor(error.master.df$error.measure)
+error.master.df$norm.method <- as.factor(error.master.df$norm.method)
 
 # rename platforms -- same as above for kappa data.frame
 error.master.df$platform <- car::recode(error.master.df$platform,
@@ -119,17 +118,16 @@ error.master.df$platform <- car::recode(error.master.df$platform,
 error.master.df$platform <- as.factor(error.master.df$platform)
 
 # reconstruction method as factor
-error.master.df$method <- as.factor(error.master.df$method)
+error.master.df$comp.method <- as.factor(error.master.df$comp.method)
 
 # take the average of each genes error across replicates 
 error.mean.df <- error.master.df %>% 
-                    group_by(gene, perc.seq, normalization, error.measure, 
-                             platform, method) %>% 
+                    group_by(gene, perc.seq, norm.method, comp.method, 
+                             platform) %>% 
                     summarise_each(funs(mean))
 rm(error.master.df)
 colnames(error.mean.df) <- c("Gene", "Perc_seq", "Normalization", 
-                             "Error_Measure", "Platform", "Method", 
-                             "Mean_Value")
+                             "Method", "Platform", "Mean_Value")
 
 # for each normalization method, plot reconstruction error
 norm.methods <- levels(error.mean.df$Normalization)
@@ -138,7 +136,7 @@ for (norm in norm.methods) {
   # violin plot is saved as a PDF
   ggplot(error.mean.df[which(error.mean.df$Normalization == norm), ], 
          aes(Perc_seq, y = Mean_Value, color = Platform, fill = Platform)) +
-    facet_wrap(Method ~ Error_Measure, ncol = 2) +
+    facet_wrap(~ Method, ncol = 2) +
     theme_bw() +
     scale_colour_manual(values = cbPalette[c(2, 3)]) +
     geom_violin(colour = "black", position = position_dodge(0.8),

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -80,6 +80,18 @@ for (norm in norm.methods) {
     theme(axis.text.x=element_text(angle = 45, vjust = 0.5)) 
   ggsave(plot.nm, plot = last_plot(), height = 8.5, width = 11)
 }
+
+# get summary data.frame + write to file
+kappa.summary.df <- 
+  kappa.master.df %>%
+    dplyr::group_by(Classifier, Normalization, Platform, Perc.seq) %>%
+    dplyr::summarise(Median = median(Kappa),
+                     Mean = mean(Kappa),
+                     SD = sd(Kappa))
+readr::write_tsv(kappa.summary.df,
+                 file.path(rcn.res.dir,
+                           "BRCA_kappa_reconstructed_data_summary_table.tsv"))
+
 rm(kappa.master.df)
 
 #### plot error measures -------------------------------------------------------


### PR DESCRIPTION
In response to reviewer comments, I have added steps to summarize the Kappa values from the supervised and unsupervised parts of the pipeline. This also corrects some outdated plotting code in this repo.