### PR TITLE
Create Dockerfile in accordance with check_installs.R

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,73 @@
+FROM rocker/tidyverse:4.0.3
+
+# Update apt-get and install other libraries
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+    awscli \
+    bzip2 \
+    curl \
+    dialog \
+    default-jdk \
+    libbz2-dev \
+    libglpk40 \
+    liblzma-dev \
+    libopenmpi-dev \
+    libreadline-dev \
+    libxt-dev \
+    openmpi-bin \
+    python3-pip \
+    python3-dev \
+    zlib1g
+
+# R packages
+RUN install2.r --error --deps TRUE \
+    ape \
+    binr \
+    caret \
+    cluster \
+    corrplot \
+    cowplot \
+    data.table \
+    devtools \
+    doParallel \
+    dplyr \
+    e1071 \
+    fastICA \
+    flexclust \
+    fpc \
+    gdata \
+    ggplot2 \
+    ggupset \
+    glmnet \
+    gridExtra \
+    here \
+    Hmisc \
+    huge \
+    kernlab \
+    optparse \
+    parallel \
+    plyr \
+    ranger \
+    RColorBrewer \
+    reshape2 \
+    scales \
+    sdcMicro \
+    stringr \
+    styler \
+    viridis
+
+# R Bioconductor packages
+RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
+  'limma', \
+  'quantro'), \
+  update = FALSE)"
+
+# Threading issue with preprocessCore::normalize.quantiles
+# https://support.bioconductor.org/p/122925/#124701
+# https://github.com/bmbolstad/preprocessCore/issues/1#issuecomment-326756305
+RUN Rscript -e "options(warn = 2); BiocManager::install( \
+    'preprocessCore', \
+    configure.args = '--disable-threading', \
+    update = FALSE)"
+
+RUN installGithub.r greenelab/TDM


### PR DESCRIPTION
Resolves https://github.com/greenelab/RNAseq_titration_results/issues/18

I created a docker image `envest/rnaseq_titration_results` by following the packages required in `check_installs.R`. There could still be tweaks to the Dockerfile but I think this gets most of the way there. I also brought in some of the packages I have learned about recently like `here` that could be useful. 

One issue I ran into when testing code (before arriving at the Killed status likely - definitely - due to not enough laptop RAM) was with `preprocessCore::normalize.quantiles()` appearing in several functions in `util/normalization_functions.R`. After googling I came across a couple of related reports ([first here](https://support.bioconductor.org/p/122925/#124701), links to package author comments [here](https://github.com/bmbolstad/preprocessCore/issues/1#issuecomment-326756305)). These posts suggested disabling threading from the package installation step à la

```
RUN Rscript -e "options(warn = 2); BiocManager::install( \
    'preprocessCore', \
    configure.args = '--disable-threading', \
    update = FALSE)"
```

From the reviewer:

- The issue with `preprocessCore` could well be something on my end and if we are running in an environment where multi-threading would be possible, maybe it is not a good idea to disable it. Is threading necessary here?
- I'm curious about my `apt-get` steps early on. Many of those utility names are inscrutable to me and I don't know what's standard practice to have around or what is superfluous. Guidance appreciated! 