### PR TITLE
Envest/update dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+.*bash_history
 .config
 .local
+.refinebio.yaml
+.Rhistory
 data
 normalized_data
 models

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,7 @@ RUN install2.r --error --deps TRUE \
 # R Bioconductor packages
 RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
     'limma', \
-    'quantro', \
-    'SCAN.UPC'), \
+    'quantro'), \
     update = FALSE)"
 
 # Threading issue with preprocessCore::normalize.quantiles
@@ -68,11 +67,3 @@ RUN Rscript -e "options(warn = 2); BiocManager::install( \
 # ref = 341eb77105e7efd2654b4f112578648584936e06 is latest greenelab/TDM commit 2021-05-28 
 RUN Rscript -e "options(warn = 2); remotes::install_github( \
     'greenelab/TDM', ref = '341eb77105e7efd2654b4f112578648584936e06')"
-
-# gdc-client
-RUN wget https://gdc.cancer.gov/files/public/file/gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
-    unzip gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
-    unzip gdc-client_v1.6.1_Ubuntu_x64.zip && \
-    mv gdc-client /usr/bin/. && \
-    rm -rf gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
-    rm -rf gdc-client_v1.6.1_Ubuntu_x64.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     python3-dev
 
-# Install pyrefinebio v0.3.0
-RUN pip3 install pyrefinebio==0.3.0
+# Install pyrefinebio v0.3.4
+RUN pip3 install pyrefinebio==0.3.4
 
 # R packages
 RUN install2.r --error --deps TRUE \
@@ -70,9 +70,9 @@ RUN Rscript -e "options(warn = 2); remotes::install_github( \
     'greenelab/TDM', ref = '341eb77105e7efd2654b4f112578648584936e06')"
 
 # gdc-client
-RUN wget https://gdc.cancer.gov/files/public/file/gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
-    unzip gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
-    unzip gdc-client_v1.6.1_Ubuntu_x64.zip && \
-    mv gdc-client /usr/bin/. && \
-    rm -rf gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
-    rm -rf gdc-client_v1.6.1_Ubuntu_x64.zip
+#RUN wget https://gdc.cancer.gov/files/public/file/gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
+#    unzip gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
+#    unzip gdc-client_v1.6.1_Ubuntu_x64.zip && \
+#    mv gdc-client /usr/bin/. && \
+#    rm -rf gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
+#    rm -rf gdc-client_v1.6.1_Ubuntu_x64.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ RUN install2.r --error --deps TRUE \
 # R Bioconductor packages
 RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
     'limma', \
-    'quantro'), \
+    'quantro', \
+    'SCAN.UPC'), \
     update = FALSE)"
 
 # Threading issue with preprocessCore::normalize.quantiles
@@ -67,3 +68,11 @@ RUN Rscript -e "options(warn = 2); BiocManager::install( \
 # ref = 341eb77105e7efd2654b4f112578648584936e06 is latest greenelab/TDM commit 2021-05-28 
 RUN Rscript -e "options(warn = 2); remotes::install_github( \
     'greenelab/TDM', ref = '341eb77105e7efd2654b4f112578648584936e06')"
+
+# gdc-client
+RUN wget https://gdc.cancer.gov/files/public/file/gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
+    unzip gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
+    unzip gdc-client_v1.6.1_Ubuntu_x64.zip && \
+    mv gdc-client /usr/bin/. && \
+    rm -rf gdc-client_v1.6.1_Ubuntu_x64-py3.7-ubuntu-16.04.zip && \
+    rm -rf gdc-client_v1.6.1_Ubuntu_x64.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,7 @@ RUN install2.r --error --deps TRUE \
 # R Bioconductor packages
 RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
     'limma', \
-    'quantro', \
-    'SCAN.UPC'), \
+    'quantro'), \
     update = FALSE)"
 
 # Threading issue with preprocessCore::normalize.quantiles


### PR DESCRIPTION
There was an issue in pyrefinebio that caused the command line option `--skip-quantile-normalization True` to be ignored.

This Dockerfile update:
- upgrades the version of pyrefinebio from 0.3.0 to 0.3.4 to incorporate that resolved functionality.
- Retains as comment the steps to download the gdc-client, which is no longer needed but may be useful one day 🌈 

We also add some files to `.gitignore`.

