### PR TITLE
Envest/12 optparse

### DIFF
--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -63,9 +63,8 @@ array.tumor.smpls <-
   clinical$Sample[which(clinical$Type == "tumor")]
 array.tumor.smpls <- substr(array.tumor.smpls, 1, 15)
 
-if (cancer_type == "BRCA") {
-  clinical <- clinical %>%
-    rename("subtype" = "PAM50")
+if (cancer_type == "BRCA") { # rename from PAM50
+  colnames(clinical)[4] <- "subtype"
 }
 
 array.subtypes <- clinical$subtype[which(clinical$Type == "tumor")]
@@ -75,6 +74,7 @@ array.data <- array.data[, c(1, which(colnames(array.data) %in%
                                         array.tumor.smpls))]
 
 # what are the overlapping sample names -- "matched" samples?
+# includes "gene" column
 sample.overlap <- intersect(colnames(array.data), colnames(seq.data))
 
 # what are the overlapping genes between the two platforms?
@@ -91,10 +91,8 @@ array.matched <- array.matched[order(array.matched$gene), ]
 seq.matched <- seq.matched[order(seq.matched$gene), ]
 
 # reorder samples on both platforms
-array.matched <- array.matched[, c(1, (order(colnames(array.matched)
-                                             [2:ncol(array.matched)]) + 1))]
-seq.matched <- seq.matched[, c(1, (order(colnames(seq.matched)
-                                         [2:ncol(seq.matched)]) + 1))]
+array.matched <- array.matched[, c(1, (order(colnames(array.matched)[-1]) + 1))]
+seq.matched <- seq.matched[, c(1, (order(colnames(seq.matched)[-1]) + 1))]
 
 #  remove subtype labels for samples missing expression data
 array.subtypes <- as.factor(array.subtypes[-which(!(array.tumor.smpls %in%

--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -94,12 +94,12 @@ seq.matched <- seq.matched[order(seq.matched$gene), ]
 array.matched <- array.matched[, c(1, (order(colnames(array.matched)[-1]) + 1))]
 seq.matched <- seq.matched[, c(1, (order(colnames(seq.matched)[-1]) + 1))]
 
-#  remove subtype labels for samples missing expression data
-array.subtypes <- as.factor(array.subtypes[-which(!(array.tumor.smpls %in%
-                                                      colnames(array.matched)))])
+# keep subtype labels for samples with expression data
+array.subtypes <- as.factor(array.subtypes[which(array.tumor.smpls %in%
+                                                      colnames(array.matched))])
 
-array.tumor.smpls <- array.tumor.smpls[-which(!(array.tumor.smpls %in%
-                                                  colnames(array.matched)))]
+array.tumor.smpls <- array.tumor.smpls[which(array.tumor.smpls %in%
+                                                  colnames(array.matched))]
 
 # remove "unmatched" / "raw" expression data
 rm(array.data, seq.data)

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -92,8 +92,13 @@ all1.list <- lapply(seq.dt.list[2:12],
                       return(indx)
                     } )
 all.1.indx <- unique(unlist(all1.list))
-array.data <- array.data[-all.1.indx, ]
-seq.data <- seq.data[-all.1.indx, ]
+# if no rows are all(x == 1) (in previous lapply), all.1.indx is integer(0)
+# subsetting data frames by -integer(0) results in no rows
+# so check that integer vector has length > 0 before subsetting
+if (length(all.1.indx) > 0) {
+  array.data <- array.data[-all.1.indx, ]
+  seq.data <- seq.data[-all.1.indx, ]  
+}
 
 #### get datatables to mix -----------------------------------------------------
 

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -5,27 +5,53 @@
 # the data.
 # It should be run from the command line through the run_experiments.R script
 
+option_list <- list(
+  optparse::make_option("--cancer_type",
+                        default = NULL,
+                        help = "Cancer type"),
+  optparse::make_option("--seed1",
+                        default = NULL,
+                        help = "Random seed"),
+  optparse::make_option("--seed2",
+                        default = NULL,
+                        help = "Random seed")
+)
+
+opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
+source("util/option_functions.R")
+check_options(opt)
+
+# load libraries
 suppressMessages(source("load_packages.R"))
 source(file.path("util", "normalization_functions.R"))
 
-args <- commandArgs(trailingOnly = TRUE)
-filename.seed <- as.integer(args[1])
-initial.seed <- as.integer(args[2])
+# set options
+cancer_type <- opt$cancer_type
+
+# set seed
+filename.seed <- as.integer(opt$seed1)
+initial.seed <- as.integer(opt$seed2)
 set.seed(initial.seed)
 
+# define directories
 data.dir <- "data"
 norm.data.dir <- "normalized_data"
-seq.file <- "BRCARNASeq_matchedOnly_ordered.pcl"
-array.file <- "BRCAarray_matchedOnly_ordered.pcl"
-norm.test.object <-
-  paste0("BRCA_array_seq_test_data_normalized_list_", filename.seed, ".RDS")
-norm.train.object <-
-  paste0("BRCA_array_seq_train_titrate_normalized_list_", filename.seed, ".RDS")
-
 res.dir <- "results"
-train.test.file <-
-  paste0("BRCA_matchedSamples_PAM50Array_training_testing_split_labels_",
-         filename.seed, ".tsv")
+
+# name input files
+seq.file <- paste0(cancer_type, "RNASeq_matchedOnly_ordered.pcl")
+array.file <- paste0(cancer_type, "array_matchedOnly_ordered.pcl")
+
+# name output files
+norm.test.object <- paste0(cancer_type,
+                           "_array_seq_test_data_normalized_list_",
+                           filename.seed, ".RDS")
+norm.train.object <- paste0(cancer_type,
+                            "_array_seq_train_titrate_normalized_list_",
+                            filename.seed, ".RDS")
+train.test.file <- paste0(cancer_type,
+                          "_matchedSamples_subtypes_training_testing_split_labels_",
+                          filename.seed, ".tsv")
 train.test.labels <- file.path(res.dir, train.test.file)
 
 #### read in data --------------------------------------------------------------

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -108,8 +108,13 @@ all1.list <- lapply(seq.dt.list[2:11],
                       return(indx)
                     } )
 all.1.indx <- unique(unlist(all1.list))
-array.data <- array.data[-all.1.indx, ]
-seq.data <- seq.data[-all.1.indx, ]
+# if no rows are all(x == 1) (in previous lapply), all.1.indx is integer(0)
+# subsetting data frames by -integer(0) results in no rows
+# so check that integer vector has length > 0 before subsetting
+if (length(all.1.indx) > 0) {
+  array.data <- array.data[-all.1.indx, ]
+  seq.data <- seq.data[-all.1.indx, ]  
+}
 
 # get a list that contains an array data.table and seq data.table for each
 # each level of 'titration'

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -64,7 +64,7 @@ subtype_vs_others.rds <- file.path(deg.dir,
 two_subtypes.rds <- file.path(deg.dir,
                               paste0(cancer_type,
                                      "_titration_differential_exp_eBayes_fits_",
-                                     two_subtypes[1], "v", two_subtypes[2], ".RDS"))
+                                     stringr::str_c(two_subtypes, collapse = "v"), ".RDS"))
 norm.rds <- file.path("normalized_data",
                       paste0(cancer_type, "_titration_no_ZTO_transform_with_UN.RDS"))
 

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -1,50 +1,86 @@
 # J. Taroni Jan 2017
 # The purpose of this analysis is to identify differentially expressed genes
-# between one BRCA subtype, specified by the user (default: Basal), and all
+# between one subtype, specified by the user, and all
 # other subtypes using the limma package for varying amounts of RNA-seq data
 # (0-100%, 10% added at a time; termed 'RNA-seq titration') and normalization
 # methods. It takes RNA-seq and microarray data from matched samples as input,
 # and performs RNA-seq titration and differential expression analysis.
 #
-# USAGE: Rscript 1A-detect_differentially_expressed_genes.R
+# USAGE: Rscript 1A-detect_differentially_expressed_genes.R --cancer_type --subtype_vs_others --subtype_vs_subtype --seed
 
+option_list <- list(
+  optparse::make_option("--cancer_type",
+                        default = NULL,
+                        help = "Cancer type"),
+  optparse::make_option("--subtype_vs_others",
+                        default = NULL,
+                        help = "Subtype used for comparison against all others"),
+  optparse::make_option("--subtype_vs_subtype",
+                        default = NULL,
+                        help = "Subtypes used in head-to-head comparison (comma-separated without space e.g. Type1,Type2)"),
+  optparse::make_option("--seed",
+                        default = 98,
+                        help = "Random seed [default: %default]")
+)
+
+opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
+source("util/option_functions.R")
+check_options(opt)
+
+# load libraries
 suppressMessages(source("load_packages.R"))
 source(file.path("util", "normalization_functions.R"))
 source(file.path("util", "differential_expression_functions.R"))
 
-args <- commandArgs(trailingOnly = TRUE)
-initial.seed <- as.integer(args[1])
-if (is.na(initial.seed)) {
-  message("\nInitial seed set to default: 98")
-  initial.seed <- 98
-} else {
-  message(paste("\nInitial seed set to:", initial.seed))
-}
-set.seed(initial.seed)
+# set options
+cancer_type <- opt$cancer_type
+subtype_vs_others <- opt$subtype_vs_others
+subtype_vs_subtype <- opt$subtype_vs_subtype
+# really this could be any number of subtypes
+two_subtypes <- as.vector(stringr::str_split(subtype_vs_subtype, pattern = ",", simplify = TRUE))
 
+# set seed
+initial.seed <- opt$seed
+set.seed(initial.seed)
+message(paste("\nInitial seed set to:", initial.seed))
+
+# define directories
 data.dir <- "data"
 deg.dir <- file.path("results", "differential_expression")
 
-seq.file <- file.path(data.dir, "BRCARNASeq_matchedOnly_ordered.pcl")
-array.file <- file.path(data.dir, "BRCAarray_matchedOnly_ordered.pcl")
-smpl.file <-
-  file.path("results",
-            "BRCA_matchedSamples_PAM50Array_training_testing_split_labels_3061.tsv")
+# define input files
+seq.file <- file.path(data.dir, paste0(cancer_type, "RNASeq_matchedOnly_ordered.pcl"))
+array.file <- file.path(data.dir, paste0(cancer_type, "array_matchedOnly_ordered.pcl"))
+smpl.file <- file.path("results",
+                       list.files("results", # this finds the first example of a subtypes file from cancer_type
+                                  pattern = paste0(cancer_type, # and does not rely on knowing a seed
+                                                   "_matchedSamples_subtypes_training_testing_split_labels_"))[1])
 
-basal.rds <-
-  file.path(deg.dir,
-            "BRCA_titration_differential_exp_eBayes_fits_BasalvOther.RDS")
-her2.rds <-
-  file.path(deg.dir,
-            "BRCA_titration_differential_exp_eBayes_fits_Her2vLumA.RDS")
+# define output files
+subtype_vs_others.rds <- file.path(deg.dir,
+                                   paste0(cancer_type,
+                                          "_titration_differential_exp_eBayes_fits_",
+                                          subtype_vs_others, "vOther.RDS"))
+two_subtypes.rds <- file.path(deg.dir,
+                              paste0(cancer_type,
+                                     "_titration_differential_exp_eBayes_fits_",
+                                     two_subtypes[1], "v", two_subtypes[2], ".RDS"))
 norm.rds <- file.path("normalized_data",
-                      "BRCA_titration_no_ZTO_transform_with_UN.RDS")
+                      paste0(cancer_type, "_titration_no_ZTO_transform_with_UN.RDS"))
 
 #### read in data --------------------------------------------------------------
 
 seq.data <- data.table::fread(seq.file, data.table = F)
 array.data <- data.table::fread(array.file, data.table = F)
 sample.df <- read.delim(smpl.file)
+
+# check that subtypes are in sample.df
+for(subtype in c(subtype_vs_others, two_subtypes)) {
+  if (!(subtype %in% sample.df$subtype)) {
+    stop(paste("Subtype", subtype, "not found in sample file",
+               smpl.file, "in 1A-detect_differentially_expressed_genes.R."))
+  }
+}
 
 sample.names <- sample.df$sample
 
@@ -125,20 +161,20 @@ norm.titrate.list[["100"]] <-
 # save normalized data
 saveRDS(norm.titrate.list, file = norm.rds)
 
-#### Basal v. Other  -----------------------------------------------------------
+#### Subtype v. Others  --------------------------------------------------------
 # design matrices
 design.mat.list <- GetDesignMatrixList(norm.titrate.list, sample.df,
-                                       subtype = "Basal")
+                                       subtype = subtype_vs_others)
 # differential expression
 fit.results.list <- GetFiteBayesList(norm.list = norm.titrate.list,
                                      design.list = design.mat.list)
 # save fit results to RDS
-saveRDS(fit.results.list, file = basal.rds)
+saveRDS(fit.results.list, file = subtype_vs_others.rds)
 
-#### Her2 v. LumA --------------------------------------------------------------
-# remove all samples that are not Her2 or LumA
+#### Subtype v. Subtype --------------------------------------------------------
+# remove all samples that are not in these subtypes
 samples.to.keep <-
-  sample.df$sample[which(sample.df$subtype %in% c("LumA", "Her2"))]
+  sample.df$sample[which(sample.df$subtype %in% two_subtypes)]
 
 pruned.norm.list <-
   lapply(norm.titrate.list,
@@ -149,11 +185,12 @@ pruned.norm.list <-
                                           with = FALSE]))
 
 # get design matrices
-her2.design.list <- GetDesignMatrixList(pruned.norm.list,
-                                        sample.df, subtype = "Her2")
+last_subtype.design.list <- GetDesignMatrixList(pruned.norm.list,
+                                                sample.df,
+                                                subtype = last(two_subtypes))
 # differential expression
-her2.fit.results.list <- GetFiteBayesList(norm.list = pruned.norm.list,
-                                          design.list = her2.design.list)
+last_subtype.fit.results.list <- GetFiteBayesList(norm.list = pruned.norm.list,
+                                                  design.list = last_subtype.design.list)
 
 # save fit results to file
-saveRDS(her2.fit.results.list, file = her2.rds)
+saveRDS(last_subtype.fit.results.list, file = two_subtypes.rds)

--- a/2A-plot_DE_results.R
+++ b/2A-plot_DE_results.R
@@ -31,7 +31,6 @@ source(file.path("util", "differential_expression_functions.R"))
 cancer_type <- opt$cancer_type
 subtype_vs_others <- opt$subtype_vs_others
 subtype_vs_subtype <- opt$subtype_vs_subtype
-# really this could be any number of subtypes
 two_subtypes <- as.vector(stringr::str_split(subtype_vs_subtype, pattern = ",", simplify = TRUE))
 
 #### plot Subtype v. Other results ---------------------------------------------
@@ -56,7 +55,7 @@ ggsave(file.path("plots", paste0(subtype_vs_others, "_v_other_jaccard_lineplot.p
 
 #### plot Subtype v. Subtype results --------------------------------------------
 subtypes_combination <- stringr::str_c(two_subtypes, collapse = "v")
-subtypes_combination_nice <- stringr::str_c(two_subtypes, collapse = " v.")
+subtypes_combination_nice <- stringr::str_c(two_subtypes, collapse = " vs. ")
 
 last_subtype.fit.list <- readRDS(file.path(
   "results", "differential_expression",

--- a/2A-plot_DE_results.R
+++ b/2A-plot_DE_results.R
@@ -5,48 +5,74 @@
 # limma::voom]) with differential expression results from RNA-seq titrated data
 # (0-100%) normalized various ways.
 #
-# USAGE: Rscript 2A-plot_DE_results.R
+# USAGE: Rscript 2A-plot_DE_results.R --cancer_type --subtype_vs_others --subtype_vs_subtype
 
-library(ggplot2)
+option_list <- list(
+  optparse::make_option("--cancer_type",
+                        default = NULL,
+                        help = "Cancer type"),
+  optparse::make_option("--subtype_vs_others",
+                        default = NULL,
+                        help = "Subtype used for comparison against all others"),
+  optparse::make_option("--subtype_vs_subtype",
+                        default = NULL,
+                        help = "Subtypes used in head-to-head comparison (comma-separated without space e.g. Type1,Type2)")
+)
+
+opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
+source("util/option_functions.R")
+check_options(opt)
+
+# load libraries
+suppressMessages(source("ggplot2"))
 source(file.path("util", "differential_expression_functions.R"))
 
-#### plot Basal v. Other results -----------------------------------------------
+# set options
+cancer_type <- opt$cancer_type
+subtype_vs_others <- opt$subtype_vs_others
+subtype_vs_subtype <- opt$subtype_vs_subtype
+# really this could be any number of subtypes
+two_subtypes <- as.vector(stringr::str_split(subtype_vs_subtype, pattern = ",", simplify = TRUE))
 
-# basal v. other fit objects
-basal.fit.list <-
-  readRDS(file.path(
-    "results", "differential_expression",
-    "BRCA_titration_differential_exp_eBayes_fits_BasalvOther.RDS"))
+#### plot Subtype v. Other results ---------------------------------------------
 
-# plot proportion of genes that are diff expressed and get topTable(s)
-basal.results <- PlotProportionDE(basal.fit.list)
-ggsave(file.path("plots",
-                 "differential_expr_proportion_ltFDR5perc_BasalvOther.pdf"),
-       plot = basal.results$plot, width = 11, height = 4.25)
-
-# plot jaccard similarity with silver standards
-basal.jacc.plot <- PlotSilverStandardJaccard(basal.results$top.table.list,
-                                             title = "Basal v. Other FDR < 5%")
-ggsave(file.path("plots", "basal_v_other_jaccard_lineplot.pdf"),
-       plot = basal.jacc.plot, width = 8.5, height = 4)
-
-
-#### plot Her2 v. LumA results -------------------------------------------------
-
-her2.fit.list <-
-  readRDS(file.path(
-    "results", "differential_expression",
-    "BRCA_titration_differential_exp_eBayes_fits_Her2vLumA.RDS"))
+# subtype v. other fit objects
+subtype_vs_others.fit.list <- readRDS(file.path("results", "differential_expression",
+  paste0(cancer_type, "_titration_differential_exp_eBayes_fits_",
+         subtype_vs_others, "vOther.RDS")))
 
 # plot proportion of genes that are diff expressed and get topTable(s)
-her2.results <- PlotProportionDE(her2.fit.list)
+subtype_vs_others.results <- PlotProportionDE(subtype_vs_others.fit.list)
 ggsave(file.path("plots",
-                 "differential_expr_proportion_ltFDR5perc_Her2vLumA.pdf"),
-       plot = her2.results$plot, width = 11, height = 4.25)
+                 paste0(cancer_type, "_differential_expr_proportion_ltFDR5perc_",
+                        subtype_vs_others, "vOther.pdf")),
+       plot = subtype_vs_others.results$plot, width = 11, height = 4.25)
 
 # plot jaccard similarity with silver standards
-her2.jacc.plot <- PlotSilverStandardJaccard(her2.results$top.table.list,
-                                            title = "Her2 v. LumA FDR < 5%")
-ggsave(file.path("plots", "her2_v_lumA_jaccard_lineplot.pdf"),
-       plot = her2.jacc.plot, width = 8.5, height = 4)
+subtype_vs_others.jacc.plot <- PlotSilverStandardJaccard(subtype_vs_others.results$top.table.list,
+                                                         title = paste(subtype_vs_others, "v. Other FDR < 5%"))
+ggsave(file.path("plots", paste0(subtype_vs_others, "_v_other_jaccard_lineplot.pdf")),
+       plot = subtype_vs_others.jacc.plot, width = 8.5, height = 4)
+
+#### plot Subtype v. Subtype results --------------------------------------------
+subtypes_combination <- stringr::str_c(two_subtypes, collapse = "v")
+subtypes_combination_nice <- stringr::str_c(two_subtypes, collapse = " v.")
+
+last_subtype.fit.list <- readRDS(file.path(
+  "results", "differential_expression",
+  paste0(cancer_type, "_titration_differential_exp_eBayes_fits_",
+         subtypes_combination, ".RDS")))
+
+# plot proportion of genes that are diff expressed and get topTable(s)
+last_subtype.results <- PlotProportionDE(last_subtype.fit.list)
+ggsave(file.path("plots",
+                 paste0(cancer_type, "_differential_expr_proportion_ltFDR5perc_",
+                        subtypes_combination, ".pdf")),
+       plot = last_subtype.results$plot, width = 11, height = 4.25)
+
+# plot jaccard similarity with silver standards
+last_subtype.jacc.plot <- PlotSilverStandardJaccard(last_subtype.results$top.table.list,
+                                                    title = paste(subtypes_combination_nice, "FDR < 5%"))
+ggsave(file.path("plots", paste0(subtypes_combination, "_jaccard_lineplot.pdf")),
+                 plot = last_subtype.jacc.plot, width = 8.5, height = 4)
 

--- a/3-plot_subtype_kappa.R
+++ b/3-plot_subtype_kappa.R
@@ -113,4 +113,4 @@ summary.df <- test.df %>%
                    SD = sd(Kappa),
                    .groups = "drop")
 readr::write_tsv(summary.df,
-                 summary_df_filename)
+                 summary.df.filename)

--- a/3-plot_subtype_kappa.R
+++ b/3-plot_subtype_kappa.R
@@ -4,19 +4,41 @@
 # through the classifier_repeat_wrapper.R script or alternatively
 # USAGE: Rscript 3-plot_subtype_kappa.R
 
+option_list <- list(
+  optparse::make_option("--cancer_type",
+                        default = NULL,
+                        help = "Cancer type")
+)
+
+opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
+source("util/option_functions.R")
+check_options(opt)
+
+# load libraries
+`%>%` <- dplyr::`%>%`
+suppressMessages(library(ggplot2))
+suppressMessages(library(data.table))
 source(file.path("util", "color_blind_friendly_palette.R"))
 
-`%>%` <- dplyr::`%>%`
-library(ggplot2)
-library(data.table)
+# set options
+cancer_type <- opt$cancer_type
 
+# define directories
 plot.dir <- "plots"
 res.dir <- "results"
-lf <- list.files(res.dir, full.names = TRUE)
-array.files <- lf[grepl("BRCA_train_3_models_array_kappa_", lf)]
-seq.files <- lf[grepl("BRCA_train_3_models_seq_kappa_", lf)]
 
-plot.file.lead <- "BRCA_train_3_models_kappa_"
+# list array and seq files from results directory
+lf <- list.files(res.dir, full.names = TRUE)
+array.files <- lf[grepl(paste0(cancer_type,
+                               "_train_3_models_array_kappa_"), lf)]
+seq.files <- lf[grepl(paste0(cancer_type,
+                             "_train_3_models_seq_kappa_"), lf)]
+
+# define output files
+plot.file.lead <- paste0(cancer_type, "_train_3_models_kappa_")
+summary.df.filename <- file.path(res.dir,
+                                 paste0(cancer_type,
+                                        "_train_3_models_summary_table.tsv"))
 
 #### read in data --------------------------------------------------------------
 
@@ -60,7 +82,7 @@ test.df$Classifier <- as.factor(test.df$Classifier)
 cls.methods <- unique(test.df$Classifier)
 for (cls in cls.methods) {
   plot.nm <- file.path(plot.dir,
-                       paste0(plot.file.lead,
+                       paste0(plot.file.lead, # includes cancer_type
                               stringr::str_replace_all(cls,
                                                        pattern = " ",
                                                        replacement = "_"),
@@ -74,7 +96,7 @@ for (cls in cls.methods) {
                  position = position_dodge(0.6)) +
     stat_summary(fun = median, geom = "point", aes(group = Platform),
                  position = position_dodge(0.7), size = 1) +
-    ggtitle(cls) +
+    ggtitle(paste0(cancer_type, ": ", cls)) +
     xlab("% RNA-seq samples") +
     theme_bw() +
     scale_colour_manual(values = cbPalette[2:3]) +
@@ -91,4 +113,4 @@ summary.df <- test.df %>%
                    SD = sd(Kappa),
                    .groups = "drop")
 readr::write_tsv(summary.df,
-                 file.path("results", "BRCA_train_3_models_summary_table.tsv"))
+                 summary_df_filename)

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -135,7 +135,7 @@ for (trial.iter in 1:10) {
   }
 
   top.table.list <-
-    lapply(master.deg.list,  # for each n (3...5)
+    lapply(master.deg.list,  # for each n (3...50)
            function(x)  # for each normalization method
              lapply(x, function(y) GetAllGenesTopTable(y)))  # extract DEGs
 

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -4,7 +4,7 @@
 # expression when there are a small number of samples on each platform
 # (50-50 split microarray and RNA-seq).
 #
-# USAGE: Rscript 3A-small_n_differential_expression.R --cancer_type --subtype_vs_subtype --max_n
+# USAGE: Rscript 3A-small_n_differential_expression.R --cancer_type --subtype_vs_subtype
 
 option_list <- list(
   optparse::make_option("--cancer_type",

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -4,32 +4,53 @@
 # expression when there are a small number of samples on each platform
 # (50-50 split microarray and RNA-seq).
 #
-# USAGE: Rscript 3A-small_n_differential_expression.R
+# USAGE: Rscript 3A-small_n_differential_expression.R --cancer_type --subtype_vs_subtype --max_n
 
+option_list <- list(
+  optparse::make_option("--cancer_type",
+                        default = NULL,
+                        help = "Cancer type"),
+  optparse::make_option("--subtype_vs_subtype",
+                        default = NULL,
+                        help = "Subtypes used in head-to-head comparison (comma-separated without space e.g. Type1,Type2)"),
+  optparse::make_option("--seed",
+                        default = 3255,
+                        help = "Random seed")
+)
+
+opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
+source("util/option_functions.R")
+check_options(opt)
+
+# load libraries
 suppressMessages(source("load_packages.R"))
 source(file.path("util", "normalization_functions.R"))
 source(file.path("util", "differential_expression_functions.R"))
 source(file.path("util", "color_blind_friendly_palette.R"))
 
-args <- commandArgs(trailingOnly = TRUE)
-initial.seed <- as.integer(args[1])
-if (is.na(initial.seed)) {
-  message("\nInitial seed set to default: 3255")
-  initial.seed <- 3255
-} else {
-  message(paste("\nInitial seed set to:", initial.seed))
-}
-set.seed(initial.seed)
+# set options
+cancer_type <- opt$cancer_type
+subtype_vs_subtype <- opt$subtype_vs_subtype
+two_subtypes <- as.vector(stringr::str_split(subtype_vs_subtype, pattern = ",", simplify = TRUE))
 
+# set seed
+initial.seed <- opt$seed
+set.seed(initial.seed)
+message(paste("\nInitial seed set to:", initial.seed))
+
+# define directories
 data.dir <- "data"
 deg.dir <- file.path("results", "differential_expression")
 
-seq.file <- file.path(data.dir, "BRCARNASeq_matchedOnly_ordered.pcl")
-array.file <- file.path(data.dir, "BRCAarray_matchedOnly_ordered.pcl")
-
-smpl.file <-
-  file.path("results",
-            "BRCA_matchedSamples_PAM50Array_training_testing_split_labels_3061.tsv")
+# define input files
+seq.file <- file.path(data.dir,
+                      paste0(cancer_type, "RNASeq_matchedOnly_ordered.pcl"))
+array.file <- file.path(data.dir,
+                        paste0(cancer_type, "array_matchedOnly_ordered.pcl"))
+smpl.file <- file.path("results",
+                       list.files("results", # this finds the first example of a subtypes file from cancer_type
+                                  pattern = paste0(cancer_type, # and does not rely on knowing a seed
+                                                   "_matchedSamples_subtypes_training_testing_split_labels_"))[1])
 
 #### functions -----------------------------------------------------------------
 
@@ -51,14 +72,22 @@ seq.data <- data.table::fread(seq.file, data.table = F)
 array.data <- data.table::fread(array.file, data.table = F)
 sample.df <- read.delim(smpl.file)
 
+# check that subtypes are in sample.df
+for(subtype in two_subtypes) {
+  if (!(subtype %in% sample.df$subtype)) {
+    stop(paste("Subtype", subtype, "not found in sample file",
+               smpl.file, "in 3A-small_n_differential_expression.R."))
+  }
+}
+
 sample.names <- sample.df$sample
 
 #### main ----------------------------------------------------------------------
 
-# leave only Her2 and LumA samples to choose from & make data.table
-# remove all samples that are not Her2 or LumA
+# leave only subtypes of interest to choose from & make data.table
+# remove all samples that are not subtypes of interest
 samples.to.keep <-
-  sample.df$sample[which(sample.df$subtype %in% c("LumA", "Her2"))]
+  sample.df$sample[which(sample.df$subtype %in% two_subtypes)]
 
 array.dt <- data.table(array.data[,
                                   c(1, which(colnames(array.data) %in%
@@ -68,8 +97,14 @@ seq.dt <- data.table(seq.data[,
                                            samples.to.keep))])
 sample.df <- sample.df[which(sample.df$sample %in% samples.to.keep), ]
 
+smaller_subtype_size <- min(table(sample.df$subtype))
+
 # different sizes of n to test
 no.samples <- c(3, 4, 5, 6, 8, 10, 15, 25, 50)
+no.samples <- no.samples[which(no.samples <= smallest_subtype_size)]
+
+message(paste("Smaller subtype has", smaller_subtype_size, "samples,",
+              "so only using up to", max(no.samples), "samples in 3A-small_n_differential_expression.R"))
 
 # initialize list to hold jaccard index data.frames from the 10 trials
 jacc.df.list <- list()
@@ -82,7 +117,7 @@ for (trial.iter in 1:10) {
   sample.list <-
     lapply(no.samples,  # for each n (3...50)
            function(x) GetSamplesforMixingSmallN(x, sample.df,
-                                                 subtype = "Her2"))
+                                                 subtype = last(two_subtypes)))
 
   # initialize list to hold differential expression results (eBayes output)
   master.deg.list <- list()
@@ -96,7 +131,7 @@ for (trial.iter in 1:10) {
     # perform differential expression analysis
     master.deg.list[[as.character(no.samples[smpl.no.iter])]] <-
       SmallNDEGWrapper(norm.list = norm.list, sample.df = sample.df,
-                       subtype = "Her2")
+                       subtype = last(two_subtypes))
   }
 
   top.table.list <-
@@ -112,13 +147,17 @@ for (trial.iter in 1:10) {
 }
 
 # combine jaccard similarity data.frames into one data.frame
-
+subtypes_combination <- stringr::str_c(two_subtypes, collapse = "v")
+subtypes_combination_nice <- stringr::str_c(two_subtypes, collapse = " vs. ")
 
 jacc.df <- data.table::rbindlist(jacc.df.list)
 
 write.table(jacc.df,
             file = file.path("results", "differential_expression",
-                             "small_n_Her2vLumA_50-50_jaccard_results.tsv"),
+                             paste0(cancer_type,
+                                    "_small_n_",
+                                    subtypes_combination,
+                                    "_50-50_jaccard_results.tsv")),
             sep = "\t", quote = FALSE, row.names = FALSE)
 
 # line plot is saved as a PDF
@@ -129,11 +168,11 @@ ggplot(jacc.df, aes(x = no.samples, y = jaccard, color = platform)) +
   stat_summary(fun.data = DataSummary, aes(group = platform),
                position = position_dodge(0.2), size = 0.2) +
   theme_bw() +
-  ggtitle("Her2 vs. LumA FDR < 10%") +
+  ggtitle(paste(subtypes_combination_nice, "FDR < 10%")) +
   ylab("Jaccard similarity to standard") +
   xlab("Number of samples (n)") +
   scale_colour_manual(values = cbPalette[c(2, 3)]) +
   theme(text = element_text(size = 18))
 ggsave(filename = file.path("plots",
-                            "small_n_Her2vLumA_50-50_jaccard_lineplots.pdf"),
+                            paste0(cancer_type, "_small_n_", subtypes_combination, "_50-50_jaccard_lineplots.pdf")),
        plot = last_plot(), width = 5, height = 7)

--- a/5-predict_subtype_reconstructed_data.R
+++ b/5-predict_subtype_reconstructed_data.R
@@ -6,30 +6,47 @@
 # confusionMatrix objects and a data.frame of Kappa statistics from these
 # predictions.
 # It should be run from the command line.
-# USAGE: Rscript 5-predict_subtype_reconstructed_data.R
+# USAGE: Rscript 5-predict_subtype_reconstructed_data.R --cancer_type
 
+option_list <- list(
+  optparse::make_option("--cancer_type",
+                        default = NULL,
+                        help = "Cancer type")
+)
+
+opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
+source("util/option_functions.R")
+check_options(opt)
+
+# load libraries
 suppressMessages(source("load_packages.R"))
 source(file.path("util", "train_test_functions.R"))
 
+# set options
+cancer_type <- opt$cancer_type
+
+# define directories
 mdl.dir <- "models"
 rcn.dir <- file.path("normalized_data", "reconstructed_data")
 res.dir <- "results"
 rcn.res.dir <- file.path(res.dir, "reconstructed_data")
 
+# define input files
 model.files <- list.files(mdl.dir, full.names = TRUE)
 supervised.model.files <- model.files[grep("3_models", model.files)]
-
 recon.files <- list.files(rcn.dir, full.names = TRUE)
 
-# get filename.seeds (identifiers for each of 10 replicates)
+# get filename.seeds (identifiers for each replicate)
 # from the reconstructed data files
 filename.seeds <- unique(substr(recon.files,
                                 (nchar(recon.files)-7),
                                 (nchar(recon.files)-4)))
 
-cm.file.lead <-
-  "BRCA_subtype_prediction_reconstructed_data_confusionMatrices_"
-kap.file.lead <- sub("confusionMatrices", "kappa", cm.file.lead)
+# define output files
+cm.file.lead <- paste0(cancer_type,
+                       "_subtype_prediction_reconstructed_data_confusionMatrices_")
+kap.file.lead <- paste0(cancer_type,
+                        "_subtype_prediction_reconstructed_data_kappa_")
 
 #### main ----------------------------------------------------------------------
 
@@ -58,8 +75,8 @@ for (seed in filename.seeds) {
   # need to read in corresponding sample.df
   sample.df.file <-
     file.path(res.dir,
-              paste0(
-                "BRCA_matchedSamples_PAM50Array_training_testing_split_labels_",
+              paste0(cancer_type,
+                "_matchedSamples_subtypes_training_testing_split_labels_",
                 seed, ".tsv"))
   sample.df <- data.table::fread(sample.df.file, data.table = F)
   sample.df$subtype <- as.factor(sample.df$subtype)

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -20,6 +20,9 @@ source(file.path("util", "color_blind_friendly_palette.R"))
 library(ggplot2)
 library(dplyr)
 
+# set options
+cancer_type <- opt$cancer_type
+
 # define directories
 plot.dir <- "plots"
 rcn.res.dir <- file.path("results", "reconstructed_data")

--- a/classifier_repeat_wrapper.R
+++ b/classifier_repeat_wrapper.R
@@ -2,16 +2,25 @@
 # This script is a wrapper for running the BRCA subtype pipeline repeatedly with
 # different random seeds.
 # It should be run from the command line.
-# USAGE: Rscript classifier_repeat_wrapper.R <n.repeats>
+# USAGE: Rscript classifier_repeat_wrapper.R --cancer_type [BRCA|GBM] --n_repeats (default: 10)
 
-args <- commandArgs(trailingOnly = TRUE)
-n.repeats <- as.integer(args[1])
-if (is.na(n.repeats)) {
-  message("\nNumber of repeats set to default: 10")
-  n.repeats <- 10
-} else {
-  message(paste("\nNumber of repeats set to", n.repeats))
-}
+option_list <- list(
+  optparse::make_option("--cancer_type",
+                        default = NULL,
+                        help = "Cancer type"),
+  optparse::make_option("--n_repeats",
+                        default = 10,
+                        help = "Number of times experiment is repeated [default: %default]")
+)
+
+opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
+source("util/option_functions.R")
+check_options(opt)
+
+# set options
+cancer_type <- opt$cancer_type
+n.repeats <- opt$n_repeats
+message(paste("\nNumber of repeats set to", n.repeats))
 
 initial.seed <- 12
 set.seed(initial.seed)
@@ -21,8 +30,8 @@ seeds <- sample(1:10000, n.repeats)
 rep.count <- 1
 for(seed in seeds){
   message(paste("\n\n#### REPEAT NUMBER", rep.count, "####\n\n"))
-  system(paste("Rscript run_experiments.R", seed))
+  system(paste("Rscript run_experiments.R", "--cancer_type", cancer_type, "--seed", seed))
   rep.count <- rep.count + 1
 }
 
-system("Rscript 3-plot_subtype_kappa.R")
+system(paste("Rscript 3-plot_subtype_kappa.R --cancer_type", cancer_type))

--- a/run_differential_expression_experiments.sh
+++ b/run_differential_expression_experiments.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
+set -euo pipefail
 
-Rscript 1A-detect_differentially_expressed_genes.R
-Rscript 2A-plot_DE_results.R
-Rscript 3A-small_n_differential_expression.R
+# cancer type (either BRCA or GBM)
+cancer_type=$1
+
+if [ $cancer_type = "BRCA" ] || [ $cancer_type = "GBM" ]; then
+  continue
+else
+  echo Cancer type must be BRCA or GBM in run_machine_learning_experiments.sh [cancer_type]
+  exit
+fi
+
+# Run differential expression scripts
+Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type
+Rscript 2A-plot_DE_results.R --cancer_type $cancer_type
+Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type

--- a/run_differential_expression_experiments.sh
+++ b/run_differential_expression_experiments.sh
@@ -12,6 +12,6 @@ else
 fi
 
 # Run differential expression scripts
-Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type
-Rscript 2A-plot_DE_results.R --cancer_type $cancer_type
-Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type
+Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type --one_vs_others $2 --one_vs_one $3
+Rscript 2A-plot_DE_results.R --cancer_type $cancer_type --one_vs_others $2 --one_vs_one $3
+Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --max_n $4 --one_vs_one $3

--- a/run_differential_expression_experiments.sh
+++ b/run_differential_expression_experiments.sh
@@ -12,9 +12,7 @@ subtype_vs_others=$2
 subtype_vs_subtype=$3
 subtype_vs_subytpe_small=$4
 
-if [ $cancer_type = "BRCA" ] || [ $cancer_type = "GBM" ]; then
-  continue
-else
+if [ $cancer_type != "BRCA" ] && [ $cancer_type != "GBM" ]; then
   echo Cancer type must be BRCA or GBM in run_machine_learning_experiments.sh [cancer_type]
   exit
 fi

--- a/run_differential_expression_experiments.sh
+++ b/run_differential_expression_experiments.sh
@@ -12,6 +12,6 @@ else
 fi
 
 # Run differential expression scripts
-Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type --one_vs_others $2 --one_vs_one $3
-Rscript 2A-plot_DE_results.R --cancer_type $cancer_type --one_vs_others $2 --one_vs_one $3
-Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --max_n $4 --one_vs_one $3
+Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type --subtype_vs_others $2 --subtype_vs_subtype $3
+Rscript 2A-plot_DE_results.R --cancer_type $cancer_type --subtype_vs_others $2 --subtype_vs_subtype $3
+Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --subtype_vs_subtype $3 --max_n $4

--- a/run_differential_expression_experiments.sh
+++ b/run_differential_expression_experiments.sh
@@ -5,10 +5,12 @@ set -euo pipefail
 # where CANCER_TYPE is one of BRCA or GBM
 # SUBTYPE_VS_OTHER is the subtype you want to compare to all others (e.g. Basal)
 # SUBTYPE_VS_SUBTYPE is the two subtypes you want to compare head to head (e.g. LumA,Her2) (comma-separated)
+# SUBTYPE_VS_SUBTYPE_SMALL is the two subtypes you want to compare head to head when limiting the sample size (e.g. LumA,Her2) (comma-separated)
 
 cancer_type=$1
 subtype_vs_others=$2
 subtype_vs_subtype=$3
+subtype_vs_subytpe_small=$4
 
 if [ $cancer_type = "BRCA" ] || [ $cancer_type = "GBM" ]; then
   continue
@@ -20,4 +22,4 @@ fi
 # Run differential expression scripts
 Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type --subtype_vs_others $2 --subtype_vs_subtype $3
 Rscript 2A-plot_DE_results.R --cancer_type $cancer_type --subtype_vs_others $2 --subtype_vs_subtype $3
-Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --subtype_vs_subtype $3
+Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --subtype_vs_subtype $4

--- a/run_differential_expression_experiments.sh
+++ b/run_differential_expression_experiments.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 set -euo pipefail
 
-# cancer type (either BRCA or GBM)
+# Usage: bash run_differential_expression_experiments.sh CANCER_TYPE SUBTYPE_VS_OTHERS SUBTYPE_VS_SUBTYPE
+# where CANCER_TYPE is one of BRCA or GBM
+# SUBTYPE_VS_OTHER is the subtype you want to compare to all others (e.g. Basal)
+# SUBTYPE_VS_SUBTYPE is the two subtypes you want to compare head to head (e.g. LumA,Her2) (comma-separated)
+
 cancer_type=$1
+subtype_vs_others=$2
+subtype_vs_subtype=$3
 
 if [ $cancer_type = "BRCA" ] || [ $cancer_type = "GBM" ]; then
   continue
@@ -14,4 +20,4 @@ fi
 # Run differential expression scripts
 Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type --subtype_vs_others $2 --subtype_vs_subtype $3
 Rscript 2A-plot_DE_results.R --cancer_type $cancer_type --subtype_vs_others $2 --subtype_vs_subtype $3
-Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --subtype_vs_subtype $3 --max_n $4
+Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --subtype_vs_subtype $3

--- a/run_experiments.R
+++ b/run_experiments.R
@@ -2,17 +2,30 @@
 # The purpose of this script is to run the BRCA subtype classifier pipeline
 # for RNA-seq 'titration.'
 # It should be run from the command line.
-# USAGE: Rscript run_experiments.R seed
-# where seed is an integer
+# USAGE: Rscript run_experiments.R --cancer_type [BRCA|GBM] --seed integer
 # It also may be run through the classifier_repeat_wrapper.R
 
-args <- commandArgs(trailingOnly = TRUE)
+option_list <- list(
+  optparse::make_option("--cancer_type",
+                        default = NULL,
+                        help = "Cancer type"),
+  optparse::make_option("--seed",
+                        default = NULL,
+                        help = "Random seed used to initiate this repeat")
+)
 
-initial.seed <- as.integer(args[1])
+opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
+source("util/option_functions.R")
+check_options(opt)
+
+initial.seed <- opt$seed
 set.seed(initial.seed)
 
 # these seeds should be between 1000 and 9999 (be 4 digits) to match later file name parsing
 seeds <- sample(1000:9999, 3)
+
+message(paste("Initial seed:", initial.seed))
+message(paste("Secondary seeds:", stringr::str_c(seeds, collapse = ", ")))
 
 message("Getting overlap and splitting into training and testing sets...")
 system(paste("Rscript 0-expression_data_overlap_and_split.R", seeds[1]))

--- a/run_experiments.R
+++ b/run_experiments.R
@@ -11,13 +11,17 @@ option_list <- list(
                         help = "Cancer type"),
   optparse::make_option("--seed",
                         default = NULL,
-                        help = "Random seed used to initiate this repeat")
+                        help = "Random seed")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
 source("util/option_functions.R")
 check_options(opt)
 
+# set options
+cancer_type <- opt$cancer_type
+
+# set seed
 initial.seed <- opt$seed
 set.seed(initial.seed)
 
@@ -28,8 +32,18 @@ message(paste("Initial seed:", initial.seed))
 message(paste("Secondary seeds:", stringr::str_c(seeds, collapse = ", ")))
 
 message("Getting overlap and splitting into training and testing sets...")
-system(paste("Rscript 0-expression_data_overlap_and_split.R", seeds[1]))
+system(paste("Rscript 0-expression_data_overlap_and_split.R",
+             "--cancer_type", cancer_type,
+             "--seed1", seeds[1]))
+
 message("\nNormalizing data...")
-system(paste("Rscript 1-normalize_titrated_data.R", seeds[1], seeds[2]))
+system(paste("Rscript 1-normalize_titrated_data.R",
+             "--cancer_type", cancer_type,
+             "--seed1", seeds[1],
+             "--seed2", seeds[2]))
+
 message("\nTraining and testing models...")
-system(paste("Rscript 2-train_test_brca_subtype.R", seeds[1], seeds[3]))
+system(paste("Rscript 2-train_test_brca_subtype.R",
+             "--cancer_type", cancer_type,
+             "--seed1", seeds[1],
+             "--seed3", seeds[3]))

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -4,9 +4,7 @@ set -euo pipefail
 # cancer type (either BRCA or GBM)
 cancer_type=$1
 
-if [ $cancer_type = "BRCA" ] || [ $cancer_type = "GBM" ]; then
-  continue
-else
+if [ $cancer_type != "BRCA" ] && [ $cancer_type != "GBM" ]; then
   echo Cancer type must be BRCA or GBM in run_machine_learning_experiments.sh [cancer_type]
   exit
 fi

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -1,9 +1,20 @@
 #!/bin/sh
+set -euo pipefail
+
+# cancer type (either BRCA or GBM)
+cancer_type=$1
+
+if [ $cancer_type = "BRCA" ] || [ $cancer_type = "GBM" ]; then
+  continue
+else
+  echo Cancer type must be BRCA or GBM in run_machine_learning_experiments.sh [cancer_type]
+  exit
+fi
 
 # Run ten repeats of the supervised analysis
-Rscript classifier_repeat_wrapper.R 10
+Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --n_repeats 10
 
 # Run the unsupervised analyses
-Rscript 4-ica_pca_feature_reconstruction.R 50
-Rscript 5-predict_subtype_reconstructed_data.R
-Rscript 6-plot_recon_error_kappa.R
+Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --n_components 50
+Rscript 5-predict_subtype_reconstructed_data.R --cancer_type $cancer_type
+Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -580,11 +580,15 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
 
   all1.indx <- unique(c(GetAllOnesRowIndex(seq.full.dt),
                         GetAllOnesRowIndex(seq.half.dt)))
-
-  array.full.dt <- array.full.dt[-all1.indx, ]
-  seq.full.dt <- seq.full.dt[-all1.indx, ]
-  array.half.dt <- array.half.dt[-all1.indx, ]
-  seq.half.dt <- seq.half.dt[-all1.indx, ]
+  # if no rows are all(x == 1) (in previous GetAllOnesRowIndex), all1.indx is integer(0)
+  # subsetting data frames by -integer(0) results in no rows
+  # so check that integer vector has length > 0 before subsetting
+  if (length(all.1.indx) > 0) {
+    array.full.dt <- array.full.dt[-all1.indx, ]
+    seq.full.dt <- seq.full.dt[-all1.indx, ]
+    array.half.dt <- array.half.dt[-all1.indx, ]
+    seq.half.dt <- seq.half.dt[-all1.indx, ]
+  }
 
   # initialize list to hold normalized data
   norm.list <- list()

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -40,10 +40,10 @@ GetDesignMat <- function(norm.dt, sample.df, subtype) {
   return(design.mat)
 }
 
-GetDesignMatrixList <- function(norm.list, sample.df, subtype = "Basal") {
+GetDesignMatrixList <- function(norm.list, sample.df, subtype) {
   # This function takes a list of normalized expression data and returns
   # a list of design matrices to be used to detect differentially expressed
-  # genes between BRCA subtype (by default: Basal) and all other subtypes with
+  # genes between one subtype and all other subtypes with
   # the limma package
   #
   # Args:
@@ -51,7 +51,7 @@ GetDesignMatrixList <- function(norm.list, sample.df, subtype = "Basal") {
   #              the list corresponds to % seq included in the expression data
   #   sample.df: a data.frame that maps the sample names to the subtype labels;
   #              'sample' and 'subtype' columns respectively
-  #   subtype: which subtype should be compared to all others? default is Basal
+  #   subtype: which subtype should be compared to all others?
   #
   #
   # Returns:
@@ -118,18 +118,8 @@ GetFiteBayes <- function(exprs, design.mat) {
 
   # detect subtype to be used for differential expression
   subtype <- colnames(design.mat)[which(colnames(design.mat) != "Other")]
-  if (subtype == "Her2") {
-    cont.eval <- "Her2vsOther= Her2-Other"
-  } else if (subtype == "LumA") {
-    cont.eval <- "LumAvsOther= LumA-Other"
-  } else if (subtype == "LumB") {
-    cont.eval <- "LumBvsOther= LumB-Other"
-  } else if (subtype == "Normal") {
-    cont.eval <- "NormalvsOther= Normal-Other"
-  } else {
-    cont.eval <- "BasalvsOther= Basal-Other"
-  }
-
+  cont.eval <- paste0(subtype, "vsOther= ", subtype, "-Other")
+  
   cont.matrix <-
     eval(parse(
       text = paste0(
@@ -452,14 +442,14 @@ GetSmallNSilverStandardJaccard <- function(top.table.list, cutoff = 0.05){
 
 }
 
-SmallNDEGWrapper <- function(norm.list, sample.df, subtype = "Basal") {
+SmallNDEGWrapper <- function(norm.list, sample.df, subtype) {
   # Perform differential expression analysis for the small n experiments
   # from a list of normalized data from SmallNNormWrapper
   #
   # Args:
   #   norm.list: a list of normalized expression data from SmallNNormWrapper
   #   sample.df: a data.frame mapping sample names to subtype labels
-  #   subtype: which subtype should be compared to all others? default is Basal
+  #   subtype: which subtype should be compared to all others?
   #
   # Returns:
   #    fit.list: a list of differential expression results for all 4 elements
@@ -495,14 +485,14 @@ SmallNDEGWrapper <- function(norm.list, sample.df, subtype = "Basal") {
 
 }
 
-GetSamplesforMixingSmallN <- function(n, sample.df, subtype = "Basal") {
+GetSamplesforMixingSmallN <- function(n, sample.df, subtype) {
   # This function is designed to identify sample names to be used in the "small
   # n" differential expression experiment
   #
   # Arg:
   #   n: number of samples (for each subtype - no. of replicates)
   #   sample.df: a data.frame mapping sample names to subtype labels
-  #   subtype: which subtype should be compared to all others? defaults to Basal
+  #   subtype: which subtype should be compared to all others
   #
   # Returns:
   #   A list comprised of the following:

--- a/util/option_functions.R
+++ b/util/option_functions.R
@@ -17,10 +17,18 @@ check_options <- function(opt) {
     } else if (option == "cancer_type") {
       
       if (!(opt[[option]] %in% c("BRCA", "GBM"))) { # cancer type must be BRCA or GBM
-        my_errors[[option]] <- strinr::str_c("\nCancer type given for --", option,
+        my_errors[[option]] <- stringr::str_c("\nCancer type given for --", option,
                                              " (", opt[[option]], ") ",
                                              " must be BRCA or GBM.")  
       }
+    } else if (option == "subtype_vs_subtype") {
+      two_subtypes <- as.vector(stringr::str_split(opt[[option]], pattern = ",", simplify = TRUE))
+      if (length(two_subtypes) != 2) {
+        my_errors[[option]] <- stringr::str_c("\nSubtypes given for --", option,
+                                             " (", opt[[option]], ") ",
+                                             " must have (only) two comma-separated subtypes.")
+      }
+      
     } else if (stringr::str_ends(option, "_input")) { # option related to inputs
       if (!file.exists(opt[[option]])) {
         my_errors[[option]] <- stringr::str_c("\nInput file given for --", option,

--- a/util/option_functions.R
+++ b/util/option_functions.R
@@ -14,6 +14,13 @@ check_options <- function(opt) {
     if (is.null(opt[[option]])) { # all required options should default to NULL
       my_errors[[option]] <- stringr::str_c("\nOption given for --", option,
                                             " is missing and must be specified.")
+    } else if (option == "cancer_type") {
+      
+      if (!(opt[[option]] %in% c("BRCA", "GBM"))) { # cancer type must be BRCA or GBM
+        my_errors[[option]] <- strinr::str_c("\nCancer type given for --", option,
+                                             " (", opt[[option]], ") ",
+                                             " must be BRCA or GBM.")  
+      }
     } else if (stringr::str_ends(option, "_input")) { # option related to inputs
       if (!file.exists(opt[[option]])) {
         my_errors[[option]] <- stringr::str_c("\nInput file given for --", option,


### PR DESCRIPTION
This pull request does the liftover from BRCA-specific scripts to optparse + cancer-type-non-specific. Because the scripts were so well-formatted already, these changes felt quite breezy to implement. So thank you.
 
Each analysis file required adding in optparse machinery at the top of the script and updating file paths to remove BRCA-specific references (including some PAM50 and subtypes)
- 0-expression_data_overlap_and_split.R
- 1-normalize_titrated_data.R
- 1A-detect_differentially_expressed_genes.R
- 2-train_test_brca_subtype.R
- 2A-plot_DE_results.R
- 3-plot_subtype_kappa.R
- 3A-small_n_differential_expression.R
- 4-ica_pca_feature_reconstruction.R
- 5-predict_subtype_reconstructed_data.R
- 6-plot_recon_error_kappa.R
- util/differential_expression_functions.R

Each shell script required adding command line options.
- classifier_repeat_wrapper.R
- run_differential_expression_experiments.sh
- run_experiments.R
- run_machine_learning_experiments.sh

These scripts included parts where we checked for rows all = 1, leading to an index of integer(0) if there were none like that. This PR makes the script check if the index has length > 0. A separate PR will have a more general solution which checks for rows with all values the same (currently testing GBM under these conditions).
- 1-normalize_titrated_data.R
- 1A-detect_differentially_expressed_genes.R
- util/differential_expression_functions.R

Here, I added some option checking:
- util/option_functions.R

In general, there are also some formatting / line spacing updates. I really appreciate the reviewer's effort given the scope of this one :)