### PR TITLE
Envest/remove rows all same

### DIFF
--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -85,19 +85,19 @@ seq.dt.list <- lapply(titrate.sample.list,
                       function(x) seq.data[, c(1, which(colnames(seq.data) %in% x))])
 seq.dt.list[["test"]] <-
   seq.data[, c(1, which(colnames(seq.data) %in% test.sample.names))]
-all1.list <- lapply(seq.dt.list[2:12],
-                    function(x){
-                      vals <- x[, 2:ncol(x)]
-                      indx <- which(apply(vals, 1, function(x) all(x == 1)))
-                      return(indx)
-                    } )
-all.1.indx <- unique(unlist(all1.list))
-# if no rows are all(x == 1) (in previous lapply), all.1.indx is integer(0)
+all.same.list <- lapply(seq.dt.list[2:12],
+                        function(x){
+                          vals <- x[, 2:ncol(x)]
+                          indx <- which(apply(vals, 1, all_same))
+                          return(indx)
+                        } )
+all.same.indx <- unique(unlist(all.same.list))
+# if no rows have all same value (in previous lapply), all.same.indx is integer(0)
 # subsetting data frames by -integer(0) results in no rows
 # so check that integer vector has length > 0 before subsetting
-if (length(all.1.indx) > 0) {
-  array.data <- array.data[-all.1.indx, ]
-  seq.data <- seq.data[-all.1.indx, ]  
+if (length(all.same.indx) > 0) {
+  array.data <- array.data[-all.same.indx, ]
+  seq.data <- seq.data[-all.same.indx, ]  
 }
 
 #### get datatables to mix -----------------------------------------------------

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -88,7 +88,7 @@ seq.dt.list[["test"]] <-
 all.same.list <- lapply(seq.dt.list[2:12],
                         function(x){
                           vals <- x[, 2:ncol(x)]
-                          indx <- which(apply(vals, 1, all_same))
+                          indx <- which(apply(vals, 1, check_all_same))
                           return(indx)
                         } )
 all.same.indx <- unique(unlist(all.same.list))

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -101,19 +101,19 @@ titrate.sample.list <-
 seq.dt.list <-
   lapply(titrate.sample.list,
          function(x) seq.data[, c(1, which(colnames(seq.data) %in% x))])
-all1.list <- lapply(seq.dt.list[2:11],
+all.same.list <- lapply(seq.dt.list[2:11],
                     function(x){
                       vals <- x[, 2:ncol(x)]
-                      indx <- which(apply(vals, 1, function(x) all(x == 1)))
+                      indx <- which(apply(vals, 1, all_same))
                       return(indx)
                     } )
-all.1.indx <- unique(unlist(all1.list))
-# if no rows are all(x == 1) (in previous lapply), all.1.indx is integer(0)
+all.same.indx <- unique(unlist(all.same.list))
+# if no rows are all same (in previous lapply), all.same.indx is integer(0)
 # subsetting data frames by -integer(0) results in no rows
 # so check that integer vector has length > 0 before subsetting
-if (length(all.1.indx) > 0) {
-  array.data <- array.data[-all.1.indx, ]
-  seq.data <- seq.data[-all.1.indx, ]  
+if (length(all.same.indx) > 0) {
+  array.data <- array.data[-all.same.indx, ]
+  seq.data <- seq.data[-all.same.indx, ]  
 }
 
 # get a list that contains an array data.table and seq data.table for each

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -104,7 +104,7 @@ seq.dt.list <-
 all.same.list <- lapply(seq.dt.list[2:11],
                     function(x){
                       vals <- x[, 2:ncol(x)]
-                      indx <- which(apply(vals, 1, all_same))
+                      indx <- which(apply(vals, 1, check_all_same))
                       return(indx)
                     } )
 all.same.indx <- unique(unlist(all.same.list))

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -575,7 +575,7 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   # z-score
   GetAllSameRowIndex <- function(x){
     vals <- x[, 2:ncol(x), with = FALSE]
-    indx <- which(apply(vals, 1, all_same))
+    indx <- which(apply(vals, 1, check_all_same))
     return(indx)
   }
   

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -571,24 +571,24 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   seq.half.dt <- seq.dt[, c(1, which(colnames(seq.dt) %in%
                                        mix.list$seq)), with = FALSE]
 
-  # remove any rows (genes) that all have count = 1, will cause issues with
+  # remove any rows (genes) that all have same values, will cause issues with
   # z-score
-  GetAllOnesRowIndex <- function(x){
+  GetAllSameRowIndex <- function(x){
     vals <- x[, 2:ncol(x), with = FALSE]
-    indx <- which(apply(vals, 1, function(x) all(x == 1)))
+    indx <- which(apply(vals, 1, all_same))
     return(indx)
   }
-
-  all1.indx <- unique(c(GetAllOnesRowIndex(seq.full.dt),
-                        GetAllOnesRowIndex(seq.half.dt)))
-  # if no rows are all(x == 1) (in previous GetAllOnesRowIndex), all1.indx is integer(0)
+  
+  all.same.indx <- unique(c(GetAllSameRowIndex(seq.full.dt),
+                            GetAllSameRowIndex(seq.half.dt)))
+  # if no rows are all same (in previous GetAllSameRowIndex), all.same.indx is integer(0)
   # subsetting data frames by -integer(0) results in no rows
   # so check that integer vector has length > 0 before subsetting
-  if (length(all.1.indx) > 0) {
-    array.full.dt <- array.full.dt[-all1.indx, ]
-    seq.full.dt <- seq.full.dt[-all1.indx, ]
-    array.half.dt <- array.half.dt[-all1.indx, ]
-    seq.half.dt <- seq.half.dt[-all1.indx, ]
+  if (length(all.same.indx) > 0) {
+    array.full.dt <- array.full.dt[-all.same.indx, ]
+    seq.full.dt <- seq.full.dt[-all.same.indx, ]
+    array.half.dt <- array.half.dt[-all.same.indx, ]
+    seq.half.dt <- seq.half.dt[-all.same.indx, ]
   }
 
   # initialize list to hold normalized data

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -1,3 +1,4 @@
+source(file.path("util", "normalization_functions.R"))
 source(file.path("util", "train_test_functions.R"))
 source(file.path("util", "color_blind_friendly_palette.R"))
 

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -344,7 +344,7 @@ SinglePlatformNormalizationWrapper <- function(dt, platform = "array",
   return(norm.list)
 }
 
-all_same <- function(x, my_tolerance = 1e-9){
+check_all_same <- function(x, my_tolerance = 1e-9){
   # This function returns TRUE if all the elements of the vector are the same
   # within a numerical tolerance levels
   # Thank you: https://stackoverflow.com/a/4752834
@@ -358,7 +358,7 @@ all_same <- function(x, my_tolerance = 1e-9){
   if (is.numeric(x) & is.numeric(my_tolerance)) {
     return(all(abs(max(x) - min(x)) < my_tolerance))  
   } else {
-    stop("Vector and tolerance given to all_same() must be numeric")
+    stop("Vector and tolerance given to check_all_same() must be numeric.")
   }
 }
 

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -344,6 +344,24 @@ SinglePlatformNormalizationWrapper <- function(dt, platform = "array",
   return(norm.list)
 }
 
+all_same <- function(x, my_tolerance = 1e-9){
+  # This function returns TRUE if all the elements of the vector are the same
+  # within a numerical tolerance levels
+  # Thank you: https://stackoverflow.com/a/4752834
+  #
+  # Args:
+  #   x: a numeric vector
+  #   my_tolerance: how close must two numbers be for them to be considered equal?
+  #
+  # Returns:
+  #   TRUE or FALSE
+  if (is.numeric(x) & is.numeric(my_tolerance)) {
+    return(all(abs(max(x) - min(x)) < my_tolerance))  
+  } else {
+    stop("Vector and tolerance given to all_same() must be numeric")
+  }
+}
+
 #### cross-platform functions --------------------------------------------------
 
 GetTitratedSampleNames <- function(sample.set, p){


### PR DESCRIPTION
This PR branches off of https://github.com/greenelab/RNAseq_titration_results/pull/47.

Before z-normalization, it's necessary to check if any rows have all the same values. If they do, NaNs crop up later. The `all_same()` function written in `util/normalization_functions.R` does this check. It returns true if a row has all the same values within a specified numerical tolerance.

This function is used in three files:
- 1-normalize_titrated_data.R
- 1A-detect_differentially_expressed_genes.R
- util/differential_expression_functions.R