### PR TITLE
Envest/43 check md5 sums

### DIFF
--- a/check_sums.tsv
+++ b/check_sums.tsv
@@ -1,0 +1,12 @@
+1a89ea769381e300e5a88ec61713ad9e	data/BRCAarray.pcl
+8c76a476c5b6f4f8deec017c876db156	data/BRCAClin.tsv
+7f00ea6ef1f309773b02e6118046550f	data/BRCARNASeq.pcl
+d4486dde14da14b4f8887a7415e2866f	data/BRCARNASeqClin.tsv
+7fafc537807d5b3ddf0bb89665279a9d	data/broad.mit.edu_PANCAN_Genome_Wide_SNP_6_whitelisted.seg
+639ad8f8386e98dacc22e439188aa8fa	data/mc3.v0.2.8.PUBLIC.maf.gz
+a4591b2dcee39591f59e5e25a6ce75fa	data/TCGA-CDR-SupplementalTableS1.xlsx
+02e72c33071307ff6570621480d3c90b	data/EBPlusPlusAdjustPANCAN_IlluminaHiSeq_RNASeqV2.geneExp.tsv
+76a0454f911aeb17276725abb760ce89	data/GSE83130/GSE83130/GSE83130.tsv
+87935b2a870781e24fdc1a9ec916cb0f	data/GSE83130/aggregated_metadata.json
+1d8834a51282396e07e3ce9a5417d024	data/gbm_clinical_table_S7.xlsx
+e5df57691b44c47b8c916116b5ac7acf	data/PanCan-General_Open_GDC-Manifest_2.txt

--- a/check_sums.tsv
+++ b/check_sums.tsv
@@ -7,6 +7,5 @@ d4486dde14da14b4f8887a7415e2866f	data/BRCARNASeqClin.tsv
 a4591b2dcee39591f59e5e25a6ce75fa	data/TCGA-CDR-SupplementalTableS1.xlsx
 02e72c33071307ff6570621480d3c90b	data/EBPlusPlusAdjustPANCAN_IlluminaHiSeq_RNASeqV2.geneExp.tsv
 76a0454f911aeb17276725abb760ce89	data/GSE83130/GSE83130/GSE83130.tsv
-87935b2a870781e24fdc1a9ec916cb0f	data/GSE83130/aggregated_metadata.json
 1d8834a51282396e07e3ce9a5417d024	data/gbm_clinical_table_S7.xlsx
 e5df57691b44c47b8c916116b5ac7acf	data/PanCan-General_Open_GDC-Manifest_2.txt

--- a/download_TCGA_data.sh
+++ b/download_TCGA_data.sh
@@ -73,7 +73,7 @@ else
 fi
 
 # check md5 sums of downloaded files
-echo Checking md5 sums of downloaded files...
+echo Checking md5 sums of downloaded files ...
 md5sum --check check_sums.tsv && echo All files downloaded match expected md5 sums!
 
 # process GBM data via script

--- a/download_TCGA_data.sh
+++ b/download_TCGA_data.sh
@@ -72,6 +72,10 @@ else
   wget -O $data/gbm_clinical_table_S7.xlsx $gbm_clinical_link
 fi
 
+# check md5 sums of downloaded files
+echo Checking md5 sums of downloaded files...
+md5sum --check check_sums.tsv && echo All files downloaded match expected md5 sums!
+
 # process GBM data via script
 echo Processing GBM data using R script prepare_GBM_data.R ...
 Rscript prepare_GBM_data.R \


### PR DESCRIPTION
Closes https://github.com/greenelab/RNAseq_titration_results/issues/43

This addition checks downloaded files to see if their md5sum matches expectation. If they all match, we can proceed with processing the downloaded data. If not, then the script stops with an informative output message (and each file is noted as either OK or FAILED).

The `check_sums.tsv` file is manually curated based on values given by zenodo and the TCGA manifest. If any file changes, we need to update the value 😸 

From the reviewer, is there a different/better way to do this? Is the screen output informative enough? Thanks!