### PR TITLE
Envest/fix small comparison

### DIFF
--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -106,7 +106,7 @@ no.samples <- c(3, 4, 5, 6, 8, 10, 15, 25, 50)
 no.samples <- no.samples[which(no.samples <= smaller_subtype_size)]
 
 message(paste("Smaller subtype has", smaller_subtype_size, "samples,",
-              "so only using up to", max(no.samples), "samples in 3A-small_n_differential_expression.R"))
+              "so using up to", max(no.samples), "samples in 3A-small_n_differential_expression.R"))
 
 # initialize list to hold jaccard index data.frames from the 10 trials
 jacc.df.list <- list()

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -99,11 +99,11 @@ seq.dt <- data.table(seq.data[,
                                            samples.to.keep))])
 sample.df <- sample.df[which(sample.df$sample %in% samples.to.keep), ]
 
-smaller_subtype_size <- min(table(sample.df$subtype))
+smaller_subtype_size <- min(table(droplevels(sample.df$subtype)))
 
 # different sizes of n to test
 no.samples <- c(3, 4, 5, 6, 8, 10, 15, 25, 50)
-no.samples <- no.samples[which(no.samples <= smallest_subtype_size)]
+no.samples <- no.samples[which(no.samples <= smaller_subtype_size)]
 
 message(paste("Smaller subtype has", smaller_subtype_size, "samples,",
               "so using up to", max(no.samples), "samples in 3A-small_n_differential_expression.R"))


### PR DESCRIPTION
This small PR recognizes that unused levels show up as 0 in a table of counts and that the minimum of a counts table that includes 0 is 0. So we need to drop unused levels such that we only keep the two levels (subtypes) of interest for the small N comparison. The maximum number of samples we can use in the small N comparison is the minimum of those two levels.