### PR TITLE
Envest/null model

### DIFF
--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -38,6 +38,8 @@ file_identifier <- ifelse(null_model,
 # set seed
 initial.seed <- as.integer(opt$seed1)
 set.seed(initial.seed)
+# set seed for spliting into train/test here, before null_model scramble
+split.seed <- sample(1:10000, 1)
 
 # define directories
 data.dir <- here::here("data")
@@ -116,6 +118,14 @@ if (any(colnames(array.matched) != colnames(seq.matched))) {
   stop("Column name reordering did not work as expected in 0-expression_data_overlap_and_split.R")
 }
 
+# if null_model, scramble expression values within sample
+# this also scrambles the gene names in column 1
+# sample() has default values replace = FALSE, so each value in column is sampled exactly once
+if (null_model) {
+  array.matched <- apply(array.matched, 2, sample)
+  seq.matched <- apply(seq.matched, 2, sample)
+}
+
 # keep category labels for samples with expression data
 array.category <- as.factor(array.category[which(array.tumor.smpls %in%
                                                    colnames(array.matched))])
@@ -142,7 +152,6 @@ write.table(seq.matched, file = seq.output.nm,
 # order array category to match the expression data order
 array.category <- array.category[order(array.tumor.smpls)]
 
-split.seed <- sample(1:10000, 1)
 message(paste("\nRandom seed for splitting into testing and training:",
               split.seed), appendLF = TRUE)
 

--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -17,7 +17,7 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Scramble gene expression values within sample for null model prediction")
+                        help = "Permute dependent variable (within subtype if predictor is a gene)")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))

--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -13,7 +13,11 @@ option_list <- list(
                         help = "Predictor used"),
   optparse::make_option("--seed1",
                         default = NA_integer_,
-                        help = "Random seed")
+                        help = "Random seed"),
+  optparse::make_option("--null_model",
+                        action = "store_true",
+                        default = FALSE,
+                        help = "Scramble gene expression values within sample for null model prediction")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -26,7 +30,10 @@ suppressMessages(source(here::here("load_packages.R")))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
-file_identifier <- str_c(cancer_type, predictor, sep = "_")
+null_model <- opt$null_model
+file_identifier <- ifelse(null_model,
+                          str_c(cancer_type, predictor, "null", sep = "_"),
+                          str_c(cancer_type, predictor, sep = "_"))
 
 # set seed
 initial.seed <- as.integer(opt$seed1)

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -35,6 +35,7 @@ source(here::here("util", "normalization_functions.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
+null_model <- opt$null_model
 file_identifier <- ifelse(null_model,
                           str_c(cancer_type, predictor, "null", sep = "_"),
                           str_c(cancer_type, predictor, sep = "_"))

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -21,7 +21,7 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Scramble gene expression values within sample for null model prediction")
+                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -17,7 +17,11 @@ option_list <- list(
                         help = "Random seed"),
   optparse::make_option("--seed2",
                         default = NA_integer_,
-                        help = "Random seed")
+                        help = "Random seed"),
+  optparse::make_option("--null_model",
+                        action = "store_true",
+                        default = FALSE,
+                        help = "Scramble gene expression values within sample for null model prediction")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -31,7 +35,9 @@ source(here::here("util", "normalization_functions.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
-file_identifier <- str_c(cancer_type, predictor, sep = "_")
+file_identifier <- ifelse(null_model,
+                          str_c(cancer_type, predictor, "null", sep = "_"),
+                          str_c(cancer_type, predictor, sep = "_"))
 
 # set seed
 filename.seed <- as.integer(opt$seed1)

--- a/2-train_test_category.R
+++ b/2-train_test_category.R
@@ -17,7 +17,11 @@ option_list <- list(
                         help = "Random seed"),
   optparse::make_option("--seed3",
                         default = NA_integer_,
-                        help = "Random seed")
+                        help = "Random seed"),
+  optparse::make_option("--null_model",
+                        action = "store_true",
+                        default = FALSE,
+                        help = "Scramble gene expression values within sample for null model prediction")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -31,7 +35,9 @@ source(here::here("util", "train_test_functions.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
-file_identifier <- str_c(cancer_type, predictor, sep = "_")
+file_identifier <- ifelse(null_model,
+                          str_c(cancer_type, predictor, "null", sep = "_"),
+                          str_c(cancer_type, predictor, sep = "_"))
 
 # set seed
 filename.seed <- opt$seed1

--- a/2-train_test_category.R
+++ b/2-train_test_category.R
@@ -35,6 +35,7 @@ source(here::here("util", "train_test_functions.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
+null_model <- opt$null_model
 file_identifier <- ifelse(null_model,
                           str_c(cancer_type, predictor, "null", sep = "_"),
                           str_c(cancer_type, predictor, sep = "_"))

--- a/2-train_test_category.R
+++ b/2-train_test_category.R
@@ -21,7 +21,7 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Scramble gene expression values within sample for null model prediction")
+                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))

--- a/3-plot_category_kappa.R
+++ b/3-plot_category_kappa.R
@@ -28,6 +28,7 @@ source(here::here("util", "color_blind_friendly_palette.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
+null_model <- opt$null_model
 file_identifier <- ifelse(null_model,
                           str_c(cancer_type, predictor, "null", sep = "_"),
                           str_c(cancer_type, predictor, sep = "_"))

--- a/3-plot_category_kappa.R
+++ b/3-plot_category_kappa.R
@@ -14,7 +14,7 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Scramble gene expression values within sample for null model prediction")
+                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))

--- a/3-plot_category_kappa.R
+++ b/3-plot_category_kappa.R
@@ -10,7 +10,11 @@ option_list <- list(
                         help = "Cancer type"),
   optparse::make_option("--predictor",
                         default = NA_character_,
-                        help = "Predictor used")
+                        help = "Predictor used"),
+  optparse::make_option("--null_model",
+                        action = "store_true",
+                        default = FALSE,
+                        help = "Scramble gene expression values within sample for null model prediction")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -24,7 +28,9 @@ source(here::here("util", "color_blind_friendly_palette.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
-file_identifier <- str_c(cancer_type, predictor, sep = "_")
+file_identifier <- ifelse(null_model,
+                          str_c(cancer_type, predictor, "null", sep = "_"),
+                          str_c(cancer_type, predictor, sep = "_"))
 
 # define directories
 plot.dir <- here::here("plots")

--- a/4-ica_pca_feature_reconstruction.R
+++ b/4-ica_pca_feature_reconstruction.R
@@ -22,7 +22,11 @@ option_list <- list(
                         help = "Number of compenents [default: %default]"),
   optparse::make_option("--seed",
                         default = 346,
-                        help = "Random seed [default: %default]")
+                        help = "Random seed [default: %default]"),
+  optparse::make_option("--null_model",
+                        action = "store_true",
+                        default = FALSE,
+                        help = "Scramble gene expression values within sample for null model prediction")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -37,7 +41,9 @@ source(here::here("util", "ICA_PCA_reconstruction_functions.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
-file_identifier <- str_c(cancer_type, predictor, sep = "_")
+file_identifier <- ifelse(null_model,
+                          str_c(cancer_type, predictor, "null", sep = "_"),
+                          str_c(cancer_type, predictor, sep = "_"))
 n.comp <- as.integer(opt$n_components)
 
 # set seed

--- a/4-ica_pca_feature_reconstruction.R
+++ b/4-ica_pca_feature_reconstruction.R
@@ -41,6 +41,7 @@ source(here::here("util", "ICA_PCA_reconstruction_functions.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
+null_model <- opt$null_model
 file_identifier <- ifelse(null_model,
                           str_c(cancer_type, predictor, "null", sep = "_"),
                           str_c(cancer_type, predictor, sep = "_"))

--- a/4-ica_pca_feature_reconstruction.R
+++ b/4-ica_pca_feature_reconstruction.R
@@ -6,7 +6,7 @@
 # error' (MASE).
 #
 # It should be run from the command line.
-# USAGE: Rscript 4-ica_pca_feature_reconstruction.R --cancer_type --predictor --n_components --seed
+# USAGE: Rscript 4-ica_pca_feature_reconstruction.R --cancer_type --predictor --n_components --seed --null_model
 # n_components refers to the number of components (PC/IC) that should be used
 # for reconstruction.
 

--- a/4-ica_pca_feature_reconstruction.R
+++ b/4-ica_pca_feature_reconstruction.R
@@ -26,7 +26,7 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Scramble gene expression values within sample for null model prediction")
+                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))

--- a/5-predict_category_reconstructed_data.R
+++ b/5-predict_category_reconstructed_data.R
@@ -14,7 +14,11 @@ option_list <- list(
                         help = "Cancer type"),
   optparse::make_option("--predictor",
                         default = NA_character_,
-                        help = "Predictor used")
+                        help = "Predictor used"),
+  optparse::make_option("--null_model",
+                        action = "store_true",
+                        default = FALSE,
+                        help = "Scramble gene expression values within sample for null model prediction")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -28,7 +32,9 @@ source(here::here("util", "train_test_functions.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
-file_identifier <- str_c(cancer_type, predictor, sep = "_")
+file_identifier <- ifelse(null_model,
+                          str_c(cancer_type, predictor, "null", sep = "_"),
+                          str_c(cancer_type, predictor, sep = "_"))
 
 # define directories
 mdl.dir <- here::here("models")
@@ -38,9 +44,18 @@ rcn.dir <- file.path(norm.dir, "reconstructed_data")
 rcn.res.dir <- file.path(res.dir, "reconstructed_data")
 
 # define input files
-model.files <- list.files(mdl.dir, full.names = TRUE)
-supervised.model.files <- model.files[grep("3_models", model.files)]
-recon.files <- list.files(rcn.dir, full.names = TRUE)
+#model.files <- list.files(mdl.dir, full.names = TRUE)
+#supervised.model.files <- model.files[grepl(paste0(file_identifier,
+#                                                   "_train_3_models"), model.files)]
+supervised.model.files <- list.files(mdl.dir,
+                                     pattern = paste0(file_identifier,
+                                                      "_train_3_models"),
+                                     full.names = TRUE)
+#recon.files <- list.files(rcn.dir, full.names = TRUE)
+recon.files <- list.files(rcn.dir,
+                          pattern = paste0(file_identifier,
+                                           "_reconstruction_error_")
+                          full.names = TRUE)
 
 # get filename.seeds (identifiers for each replicate)
 # from the reconstructed data files

--- a/5-predict_category_reconstructed_data.R
+++ b/5-predict_category_reconstructed_data.R
@@ -55,7 +55,7 @@ supervised.model.files <- list.files(mdl.dir,
 #recon.files <- list.files(rcn.dir, full.names = TRUE)
 recon.files <- list.files(rcn.dir,
                           pattern = paste0(file_identifier,
-                                           "_reconstruction_error_"),
+                                           "_reconstructed_data_"),
                           full.names = TRUE)
 
 # get filename.seeds (identifiers for each replicate)

--- a/5-predict_category_reconstructed_data.R
+++ b/5-predict_category_reconstructed_data.R
@@ -45,14 +45,10 @@ rcn.dir <- file.path(norm.dir, "reconstructed_data")
 rcn.res.dir <- file.path(res.dir, "reconstructed_data")
 
 # define input files
-#model.files <- list.files(mdl.dir, full.names = TRUE)
-#supervised.model.files <- model.files[grepl(paste0(file_identifier,
-#                                                   "_train_3_models"), model.files)]
 supervised.model.files <- list.files(mdl.dir,
                                      pattern = paste0(file_identifier,
                                                       "_train_3_models"),
                                      full.names = TRUE)
-#recon.files <- list.files(rcn.dir, full.names = TRUE)
 recon.files <- list.files(rcn.dir,
                           pattern = paste0(file_identifier,
                                            "_reconstructed_data_"),

--- a/5-predict_category_reconstructed_data.R
+++ b/5-predict_category_reconstructed_data.R
@@ -6,7 +6,7 @@
 # confusionMatrix objects and a data.frame of Kappa statistics from these
 # predictions.
 # It should be run from the command line.
-# USAGE: Rscript 5-predict_category_reconstructed_data.R --cancer_type --predictor
+# USAGE: Rscript 5-predict_category_reconstructed_data.R --cancer_type --predictor --null_model
 
 option_list <- list(
   optparse::make_option("--cancer_type",

--- a/5-predict_category_reconstructed_data.R
+++ b/5-predict_category_reconstructed_data.R
@@ -32,6 +32,7 @@ source(here::here("util", "train_test_functions.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
+null_model <- opt$null_model
 file_identifier <- ifelse(null_model,
                           str_c(cancer_type, predictor, "null", sep = "_"),
                           str_c(cancer_type, predictor, sep = "_"))

--- a/5-predict_category_reconstructed_data.R
+++ b/5-predict_category_reconstructed_data.R
@@ -55,7 +55,7 @@ supervised.model.files <- list.files(mdl.dir,
 #recon.files <- list.files(rcn.dir, full.names = TRUE)
 recon.files <- list.files(rcn.dir,
                           pattern = paste0(file_identifier,
-                                           "_reconstruction_error_")
+                                           "_reconstruction_error_"),
                           full.names = TRUE)
 
 # get filename.seeds (identifiers for each replicate)

--- a/5-predict_category_reconstructed_data.R
+++ b/5-predict_category_reconstructed_data.R
@@ -18,7 +18,7 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Scramble gene expression values within sample for null model prediction")
+                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -3,7 +3,7 @@
 # 4-ica_pca_feature_reconstruction.R and the Kappa statistics associated with
 # predictions on reconstructed data from 5-predict_category_reconstructed_data.R
 # as violin plots, respectively.
-# USAGE: Rscript 6-plot_recon_error_kappa.R --cancer_type --predictor
+# USAGE: Rscript 6-plot_recon_error_kappa.R --cancer_type --predictor --null_model
 
 option_list <- list(
   optparse::make_option("--cancer_type",

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -29,6 +29,7 @@ source(here::here("util", "color_blind_friendly_palette.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
+null_model <- opt$null_model
 file_identifier <- ifelse(null_model,
                           str_c(cancer_type, predictor, "null", sep = "_"),
                           str_c(cancer_type, predictor, sep = "_"))

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -11,7 +11,11 @@ option_list <- list(
                         help = "Cancer type"),
   optparse::make_option("--predictor",
                         default = NA_character_,
-                        help = "Predictor used")
+                        help = "Predictor used"),
+  optparse::make_option("--null_model",
+                        action = "store_true",
+                        default = FALSE,
+                        help = "Scramble gene expression values within sample for null model prediction")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -25,7 +29,9 @@ source(here::here("util", "color_blind_friendly_palette.R"))
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
-file_identifier <- str_c(cancer_type, predictor, sep = "_")
+file_identifier <- ifelse(null_model,
+                          str_c(cancer_type, predictor, "null", sep = "_"),
+                          str_c(cancer_type, predictor, sep = "_"))
 
 # define directories
 plot.dir <- here::here("plots")

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -15,7 +15,7 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Scramble gene expression values within sample for null model prediction")
+                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))

--- a/classifier_repeat_wrapper.R
+++ b/classifier_repeat_wrapper.R
@@ -2,7 +2,7 @@
 # This script is a wrapper for running the BRCA subtype pipeline repeatedly with
 # different random seeds.
 # It should be run from the command line.
-# USAGE: Rscript classifier_repeat_wrapper.R --cancer_type [BRCA|GBM] --predictor [subtype|TP53|PIK3CA] --n_repeats (default: 10)
+# USAGE: Rscript classifier_repeat_wrapper.R --cancer_type [BRCA|GBM] --predictor [subtype|TP53|PIK3CA] --n_repeats (default: 10) --null_model
 
 option_list <- list(
   optparse::make_option("--cancer_type",
@@ -17,7 +17,7 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Scramble gene expression values within sample for null model prediction")
+                        help = "Permute dependent variable (within subtype if predictor is a gene)")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))

--- a/classifier_repeat_wrapper.R
+++ b/classifier_repeat_wrapper.R
@@ -13,7 +13,11 @@ option_list <- list(
                         help = "Predictor used"),
   optparse::make_option("--n_repeats",
                         default = 10,
-                        help = "Number of times experiment is repeated [default: %default]")
+                        help = "Number of times experiment is repeated [default: %default]"),
+  optparse::make_option("--null_model",
+                        action = "store_true",
+                        default = FALSE,
+                        help = "Scramble gene expression values within sample for null model prediction")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -24,6 +28,13 @@ check_options(opt)
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
 n.repeats <- opt$n_repeats
+null_model <- opt$null_model
+
+message(paste("\nPredicting", predictor,
+              "in", cancer_type,
+              ifelse(null_model,
+                     "(null model) ...",
+                     "...")))
 message(paste("\nNumber of repeats set to", n.repeats))
 
 initial.seed <- 12
@@ -37,10 +48,16 @@ for(seed in seeds){
   system(paste("Rscript run_experiments.R",
                "--cancer_type", cancer_type,
                "--predictor", predictor,
-               "--seed", seed))
+               "--seed", seed,
+               ifelse(null_model,
+                      "--null_model",
+                      "")))
   rep.count <- rep.count + 1
 }
 
 system(paste("Rscript 3-plot_category_kappa.R",
              "--cancer_type", cancer_type,
-             "--predictor", predictor))
+             "--predictor", predictor,
+             ifelse(null_model,
+                    "--null_model",
+                    "")))

--- a/run_experiments.R
+++ b/run_experiments.R
@@ -14,7 +14,11 @@ option_list <- list(
                         help = "Predictor used"),
   optparse::make_option("--seed",
                         default = NA_integer_,
-                        help = "Random seed")
+                        help = "Random seed"),
+  optparse::make_option("--null_model",
+                        action = "store_true",
+                        default = FALSE,
+                        help = "Scramble gene expression values within sample for null model prediction")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -24,6 +28,7 @@ check_options(opt)
 # set options
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
+null_model <- opt$null_model
 
 # set seed
 initial.seed <- opt$seed
@@ -39,18 +44,27 @@ message("Getting overlap and splitting into training and testing sets...")
 system(paste("Rscript 0-expression_data_overlap_and_split.R",
              "--cancer_type", cancer_type,
              "--predictor", predictor,
-             "--seed1", seeds[1]))
+             "--seed1", seeds[1],
+             ifelse(null_model,
+                    "--null_model",
+                    "")))
 
 message("\nNormalizing data...")
 system(paste("Rscript 1-normalize_titrated_data.R",
              "--cancer_type", cancer_type,
              "--predictor", predictor,
              "--seed1", seeds[1],
-             "--seed2", seeds[2]))
+             "--seed2", seeds[2],
+             ifelse(null_model,
+                    "--null_model",
+                    "")))
 
 message("\nTraining and testing models...")
 system(paste("Rscript 2-train_test_category.R",
              "--cancer_type", cancer_type,
              "--predictor", predictor,
              "--seed1", seeds[1],
-             "--seed3", seeds[3]))
+             "--seed3", seeds[3],
+             ifelse(null_model,
+                    "--null_model",
+                    "")))

--- a/run_experiments.R
+++ b/run_experiments.R
@@ -2,7 +2,7 @@
 # The purpose of this script is to run the BRCA subtype classifier pipeline
 # for RNA-seq 'titration.'
 # It should be run from the command line.
-# USAGE: Rscript run_experiments.R --cancer_type [BRCA|GBM] --predictor [subtype|TP53|PIK3CA] --seed integer
+# USAGE: Rscript run_experiments.R --cancer_type [BRCA|GBM] --predictor [subtype|TP53|PIK3CA] --seed integer --null_model
 # It also may be run through the classifier_repeat_wrapper.R
 
 option_list <- list(
@@ -18,7 +18,7 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Scramble gene expression values within sample for null model prediction")
+                        help = "Permute dependent variable (within subtype if predictor is a gene)")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -16,6 +16,7 @@ if [ $predictor != "subtype" ] && [ $predictor != "TP53" ] && [ $predictor != "P
 fi
 
 # Run ten repeats of the supervised analysis
+# if the predictor is a gene, also generate null models
 if [ $predictor == "TP53" ] || [ $predictor == "PIK3CA" ]; then
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -10,13 +10,18 @@ if [ $cancer_type != "BRCA" ] && [ $cancer_type != "GBM" ]; then
   exit
 fi
 
-if [ $predictor != "subtype" ] && [ $predictor != "TP53" ] && [ $predictor != "PIK3CA"]; then
+if [ $predictor != "subtype" ] && [ $predictor != "TP53" ] && [ $predictor != "PIK3CA" ]; then
   echo Predictor must be subtype, TP53, or PIK3CA in run_machine_learning_experiments.sh [cancer_type] [predictor]
   exit
 fi
 
 # Run ten repeats of the supervised analysis
-Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
+if [ $predictor == "TP53" ] || [ $predictor == "PIK3CA" ]; then
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model
+else
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
+fi
 
 # Run the unsupervised analyses
 Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50


### PR DESCRIPTION
This PR adds the ability to create a null prediction model by shuffling gene expression values within a sample.

The actual shuffling step happens one time at new lines 121-128 in `0-expression_data_overlap_and_split.R`:
- If `null_model` is TRUE (deafult is FALSE), then apply the `sample` function to each column.
- This also shuffles the gene names, without consequence, although maybe better to not shuffle gene names. Comments welcome.
- This is applied to the matched array and seq data after all the reordering and overlapping has occurred. 

The repeated housekeeping mechanics to achieve this are:
- Add `null_model` option to each script
- Use `ifelse()` to define the `file_identifier` as either `CANCERTYPE_PREDICTOR` or `CANCERTYPE_PREDICTOR_NULL`
- Define the input files to `5-predict_category_reconstructed_data.R` more consistently
- Append `--null_model` to `system()` calls in `run_machine_learning_experiments.sh`, `classifier_repeat_wrapper.R` and `run_experiments.R`.
- Ensure the same test/train split random seed is the same for both null and non-null model by setting that seed before random sampling happens (added to lines 41-42 in `0-expression_data_overlap_and_split.R`)

This PR is upstream of adding in subtype as a covariate when predicting mutation status. Another downstream PR will look at plotting delta kappa. For now, we are just creating a null prediction model.

From the reviewer, my scientific question is: is shuffling _within sample_ the right decision?

Thanks!