### PR TITLE
Envest/ensure consistent test train split

### DIFF
--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -195,8 +195,16 @@ write.table(lbl.df,
 cbPalette <- c("#000000", "#E69F00", "#56B4E9",
                "#009E73", "#F0E442","#0072B2", "#D55E00", "#CC79A7")
 
+plot.df <- lbl.df %>%
+  mutate(split = "whole") %>%
+  bind_rows(lbl.df %>%
+              mutate(case_when(split == "train" ~ "train (2/3)",
+                               split == "test" ~ "test (1/3)")))
+
+print(plot.df %>% count(split))
+
 plot.nm <- file.path(plot.dir, category.distribtion.plot)
-ggplot(lbl.df, aes(x = split, fill = category)) +
+ggplot(plot.df, aes(x = split, fill = category)) +
   geom_bar() +
   theme_classic() +
   scale_fill_manual(values = cbPalette) +

--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -196,10 +196,9 @@ cbPalette <- c("#000000", "#E69F00", "#56B4E9",
                "#009E73", "#F0E442","#0072B2", "#D55E00", "#CC79A7")
 
 plot.df <- lbl.df %>%
-  mutate(split = "whole") %>%
-  bind_rows(lbl.df %>%
-              mutate(case_when(split == "train" ~ "train (2/3)",
-                               split == "test" ~ "test (1/3)")))
+  mutate(split = case_when(split == "train" ~ "train (2/3)",
+                           split == "test" ~ "test (1/3)")) %>%
+  bind_rows(lbl.df %>% mutate(split = "whole"))
 
 print(plot.df %>% count(split))
 

--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -200,8 +200,6 @@ plot.df <- lbl.df %>%
                            split == "test" ~ "test (1/3)")) %>%
   bind_rows(lbl.df %>% mutate(split = "whole"))
 
-print(plot.df %>% count(split))
-
 plot.nm <- file.path(plot.dir, category.distribtion.plot)
 ggplot(plot.df, aes(x = split, fill = category)) +
   geom_bar() +

--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -177,12 +177,14 @@ if (null_model) {
   if (predictor == "subtype") { # here, subtype = category
     lbl.df <- lbl.df %>%
       group_by(split) %>%
-      mutate(category = sample(category)) %>%
+      mutate(category = case_when(split == "train" ~ sample(category),
+                                  split == "test" ~ category)) %>%
       ungroup()
   } else { # if predictor not subtype, then must be mutation
     lbl.df <- lbl.df %>% # subtype = subtype, category = TP53 or PIK3CA 0/1
       group_by(split, subtype) %>% # sample within subtype
-      mutate(category = sample(category)) %>%
+      mutate(category = case_when(split == "train" ~ sample(category),
+                                  split == "test" ~ category)) %>%
       ungroup()
   }
 }

--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -168,17 +168,20 @@ if (predictor != "subtype") {
 
 #### permute category labels for null model ------------------------------------
 # this comes after createDataPartition() to ensure same samples go to train/test
-# it may mess up the precise partitioning but train/test sets must be consistent
+# grouping by split ensure labels remain balanced within train and test
 # if null_model is specified and predicting subtype, permute subtype labels
 # if null_model is specified and predicting mutation status,
 #   permute mutation labels WITHIN subtype
 
 if (null_model) {
   if (predictor == "subtype") { # here, subtype = category
-    lbl.df$category <- sample(lbl$category)    
+    lbl.df <- lbl.df %>%
+      group_by(split) %>%
+      mutate(category = sample(category)) %>%
+      ungroup()
   } else { # if predictor not subtype, then must be mutation
     lbl.df <- lbl.df %>% # subtype = subtype, category = TP53 or PIK3CA 0/1
-      group_by(subtype) %>% # sample within subtype
+      group_by(split, subtype) %>% # sample within subtype
       mutate(category = sample(category)) %>%
       ungroup()
   }

--- a/0-expression_data_overlap_and_split.R
+++ b/0-expression_data_overlap_and_split.R
@@ -79,20 +79,6 @@ clinical <- clinical %>%
   filter(Type == "tumor") %>%
   tidyr::drop_na()
 
-# if null_model is specified and predicting subtype, permute subtype labels
-# if null_model is specified and predicting mutation status,
-#   permute mutation labels WITHIN subtype
-if (null_model) {
-  if (predictor == "subtype") { # here, subtype = category
-    clinical$category <- sample(clinical$category)    
-  } else { # if predictor not subtype, then must be mutation
-    clinical <- clinical %>% # subtype = subtype, category = TP53 or PIK3CA
-      group_by(subtype) %>% # sample within subtype
-      mutate(category = sample(category)) %>%
-      ungroup()
-  }
-}
-
 # change first column name to "gene"
 colnames(array.data)[1] <- colnames(seq.data)[1] <- "gene"
 
@@ -164,38 +150,53 @@ message(paste("\nRandom seed for splitting into testing and training:",
 set.seed(split.seed)
 train.index <- unlist(createDataPartition(array.category, times = 1, p = (2/3)))
 
-#### plot category distributions ------------------------------------------------
-whole.df <- cbind(as.character(array.category),
-                  rep("whole", length(array.category)))
-train.df <- cbind(as.character(array.category[train.index]),
-                  rep("train (2/3)", length(train.index)))
-test.df <- cbind(as.character(array.category[-train.index]),
-                 rep("test (1/3)",
-                     length(array.category)-length(train.index)))
-mstr.df <- rbind(whole.df, train.df, test.df)
+#### write training/test labels to file ----------------------------------------
 
-colnames(mstr.df) <- c("category", "split")
+lbl <- rep("test", length(array.tumor.smpls))
+lbl[train.index] <- "train"
+lbl.df <- tibble(sample = colnames(array.matched)[2:ncol(array.matched)],
+                 split = lbl,
+                 category = as.character(array.category))
+
+# add back subtype if predicting gene
+if (predictor != "subtype") {
+  lbl.df <- lbl.df %>% 
+    left_join(clinical %>%
+                select(Sample, subtype),
+              by = c("sample" = "Sample"))
+}
+
+#### permute category labels for null model ------------------------------------
+# this comes after createDataPartition() to ensure same samples go to train/test
+# it may mess up the precise partitioning but train/test sets must be consistent
+# if null_model is specified and predicting subtype, permute subtype labels
+# if null_model is specified and predicting mutation status,
+#   permute mutation labels WITHIN subtype
+
+if (null_model) {
+  if (predictor == "subtype") { # here, subtype = category
+    lbl.df$category <- sample(lbl$category)    
+  } else { # if predictor not subtype, then must be mutation
+    lbl.df <- lbl.df %>% # subtype = subtype, category = TP53 or PIK3CA 0/1
+      group_by(subtype) %>% # sample within subtype
+      mutate(category = sample(category)) %>%
+      ungroup()
+  }
+}
+
+write.table(lbl.df,
+            file = file.path(res.dir, train.test.labels),
+            quote = FALSE, sep = "\t", row.names = FALSE)
+
+#### plot category distributions ------------------------------------------------
 cbPalette <- c("#000000", "#E69F00", "#56B4E9",
                "#009E73", "#F0E442","#0072B2", "#D55E00", "#CC79A7")
 
 plot.nm <- file.path(plot.dir, category.distribtion.plot)
-ggplot(as.data.frame(mstr.df), aes(x = split, fill = category)) +
+ggplot(lbl.df, aes(x = split, fill = category)) +
   geom_bar() +
   theme_classic() +
   scale_fill_manual(values = cbPalette) +
   ggsave(plot.nm,
          height = 6,
          width = 6)
-
-#### write training/test labels to file ----------------------------------------
-
-lbl <- rep("test", length(array.tumor.smpls))
-lbl[train.index] <- "train"
-lbl.df <- cbind(colnames(array.matched)[2:ncol(array.matched)],
-                lbl,
-                as.character(array.category))
-colnames(lbl.df) <- c("sample", "split", "category")
-
-write.table(lbl.df,
-            file = file.path(res.dir, train.test.labels),
-            quote = FALSE, sep = "\t", row.names = FALSE)


### PR DESCRIPTION
🤦 I realized there was a problem after merging https://github.com/greenelab/RNAseq_titration_results/pull/64: were are getting different samples in train/test set when creating the null model compared to the non-null model.

Script `0-expression_data_overlap_and_split.R` uses `createDataPartition(array.category, times = 1, p = (2/3))` to assign samples to the training or test set while maintaining balance in the outcome variable, `array.category`.

Previously, when permuting gene expression values to create the null model, this was not a problem because the `array.category` value was the same in the null and non-null model. This is something I had checked to make sure the same samples were assigned to training and test. However, now that we permute `array.category` to create the null model, `createDataPartition()` returns a different result for null and non-null models (despite setting the same seed). This is not the desired behavior! We want to have pairs of null and non-null models that have the same samples in the train and test sets. I had not checked this after making the change to our permutation strategy.

One solution to this is rearranging the order of operations such that `createDataPartition()` is working on the same input vector each time. This means that when we create the null model, we permute labels _after_ creating the partition. To make sure classes remain balanced, permutation is done within the training or test set only. When the outcome variable is a gene, we also permute within subtype (as previously reviewed). Once the permutation is done, we can plot to show 2/3 of data goes to training and 1/3 to test, and that the classes are balanced.

Thanks for looking back over this rearrangement of things!