### PR TITLE
Remove .groups column from grouped operations

### DIFF
--- a/3-plot_category_kappa.R
+++ b/3-plot_category_kappa.R
@@ -120,7 +120,7 @@ summary.df <- test.df %>%
   dplyr::group_by(Classifier, Normalization, Platform, Perc.Seq) %>%
   dplyr::summarise(Median = median(Kappa),
                    Mean = mean(Kappa),
-                   SD = sd(Kappa),
-                   .groups = "drop")
+                   SD = sd(Kappa)) %>%
+  ungroup()
 readr::write_tsv(summary.df,
                  summary.df.filename)

--- a/3-plot_category_kappa.R
+++ b/3-plot_category_kappa.R
@@ -121,6 +121,6 @@ summary.df <- test.df %>%
   dplyr::summarise(Median = median(Kappa),
                    Mean = mean(Kappa),
                    SD = sd(Kappa)) %>%
-  ungroup()
+  dplyr::ungroup()
 readr::write_tsv(summary.df,
                  summary.df.filename)

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -115,8 +115,8 @@ kappa.summary.df <-
   dplyr::group_by(Classifier, Normalization, Platform, Perc.seq) %>%
   dplyr::summarise(Median = median(Kappa),
                    Mean = mean(Kappa),
-                   SD = sd(Kappa),
-                   .groups = "drop")
+                   SD = sd(Kappa)) %>%
+  ungroup()
 readr::write_tsv(kappa.summary.df,
                  file.path(rcn.res.dir,
                            paste0(file_identifier,
@@ -155,7 +155,8 @@ error.mean.df <- error.master.df %>%
   dplyr::group_by(gene, perc.seq, norm.method, comp.method,
                   platform) %>%
   dplyr::summarise(mean_mase = mean(MASE),
-                   .groups = "drop")
+                   .groups = "drop") %>%
+  ungroup()
 rm(error.master.df)
 colnames(error.mean.df) <- c("Gene", "Perc_seq", "Normalization",
                              "Method", "Platform", "Mean_Value")

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -154,8 +154,7 @@ error.master.df$comp.method <- as.factor(error.master.df$comp.method)
 error.mean.df <- error.master.df %>%
   dplyr::group_by(gene, perc.seq, norm.method, comp.method,
                   platform) %>%
-  dplyr::summarise(mean_mase = mean(MASE),
-                   .groups = "drop") %>%
+  dplyr::summarise(mean_mase = mean(MASE)) %>%
   ungroup()
 rm(error.master.df)
 colnames(error.mean.df) <- c("Gene", "Perc_seq", "Normalization",

--- a/6-plot_recon_error_kappa.R
+++ b/6-plot_recon_error_kappa.R
@@ -116,7 +116,7 @@ kappa.summary.df <-
   dplyr::summarise(Median = median(Kappa),
                    Mean = mean(Kappa),
                    SD = sd(Kappa)) %>%
-  ungroup()
+  dplyr::ungroup()
 readr::write_tsv(kappa.summary.df,
                  file.path(rcn.res.dir,
                            paste0(file_identifier,
@@ -155,7 +155,7 @@ error.mean.df <- error.master.df %>%
   dplyr::group_by(gene, perc.seq, norm.method, comp.method,
                   platform) %>%
   dplyr::summarise(mean_mase = mean(MASE)) %>%
-  ungroup()
+  dplyr::ungroup()
 rm(error.master.df)
 colnames(error.mean.df) <- c("Gene", "Perc_seq", "Normalization",
                              "Method", "Platform", "Mean_Value")


### PR DESCRIPTION
Closes #66 

This small change prevents addition of an extra unnecessary column called ".groups", which was an artifact of moving from `dplyr` version >= 1 to `dplyr` version < 1.

Previously, there were a few places we added an option `.groups = "drop"` to grouped functions like `summarize()` to drop all groups afterward. That's not a feature of `dplyr` version < 1, so instead a column named `.groups` was added with value "drop". Here I have removed the `.groups` argument and added `ungroup()` right after to be sure there is no grouping kept. I'm not sure whether there is a solution that works in both `dplyr` epochs but I would prefer an innocuous screen message (what we will get with updated code in `dplyr` >= 1 for an unnecessary column (what we get without change in `dplyr` < 1).

Thanks :) 