### PR TITLE
Envest/57 clean up download script

### DIFF
--- a/combine_clinical_data.R
+++ b/combine_clinical_data.R
@@ -37,12 +37,12 @@ combined_output_filepath <- opt$combined_output
 ################################################################################
 # Read in clinical and mutation data
 ################################################################################
-clinical_df <- read_tsv(clinical_input_filepath,
-                        col_types = cols()) %>% # suppress column type screen output
+clinical_df <- read_tsv(clinical_input_filepath, # treat all columns equally
+                        col_types = cols(.default = col_character())) %>%
   mutate(Sample = substr(Sample, 1, 15)) # remove extra parts of TCGA ID
 
-mutation_df <- read_tsv(mutation_input_filepath,
-                        col_types = cols()) %>% # suppress column type screen output
+mutation_df <- read_tsv(mutation_input_filepath, # treat all columns equally
+                        col_types = cols(.default = col_character())) %>%
   mutate(tcga_id = substr(tcga_id, 1, 15)) # remove extra parts of TCGA ID
 
 ################################################################################

--- a/combine_clinical_data.R
+++ b/combine_clinical_data.R
@@ -36,13 +36,14 @@ combined_output_filepath <- opt$combined_output
 
 ################################################################################
 # Read in clinical and mutation data
+# use col_types = "c" to be consistent across all files
 ################################################################################
 clinical_df <- read_tsv(clinical_input_filepath,
-                        col_types = cols()) %>% # suppress column type screen output
+                        col_types = "c") %>%
   mutate(Sample = substr(Sample, 1, 15)) # remove extra parts of TCGA ID
 
 mutation_df <- read_tsv(mutation_input_filepath,
-                        col_types = cols()) %>% # suppress column type screen output
+                        col_types = "c") %>%
   mutate(tcga_id = substr(tcga_id, 1, 15)) # remove extra parts of TCGA ID
 
 ################################################################################

--- a/combine_clinical_data.R
+++ b/combine_clinical_data.R
@@ -36,14 +36,13 @@ combined_output_filepath <- opt$combined_output
 
 ################################################################################
 # Read in clinical and mutation data
-# use col_types = "c" to be consistent across all files
 ################################################################################
 clinical_df <- read_tsv(clinical_input_filepath,
-                        col_types = "c") %>%
+                        col_types = cols()) %>% # suppress column type screen output
   mutate(Sample = substr(Sample, 1, 15)) # remove extra parts of TCGA ID
 
 mutation_df <- read_tsv(mutation_input_filepath,
-                        col_types = "c") %>%
+                        col_types = cols()) %>% # suppress column type screen output
   mutate(tcga_id = substr(tcga_id, 1, 15)) # remove extra parts of TCGA ID
 
 ################################################################################

--- a/combine_clinical_data.R
+++ b/combine_clinical_data.R
@@ -37,10 +37,12 @@ combined_output_filepath <- opt$combined_output
 ################################################################################
 # Read in clinical and mutation data
 ################################################################################
-clinical_df <- read_tsv(clinical_input_filepath) %>%
+clinical_df <- read_tsv(clinical_input_filepath,
+                        col_types = cols()) %>% # suppress column type screen output
   mutate(Sample = substr(Sample, 1, 15)) # remove extra parts of TCGA ID
 
-mutation_df <- read_tsv(mutation_input_filepath) %>%
+mutation_df <- read_tsv(mutation_input_filepath,
+                        col_types = cols()) %>% # suppress column type screen output
   mutate(tcga_id = substr(tcga_id, 1, 15)) # remove extra parts of TCGA ID
 
 ################################################################################

--- a/download_TCGA_data.sh
+++ b/download_TCGA_data.sh
@@ -11,9 +11,6 @@ mkdir -p $data
 # downlaod BRCA array and seq data from URLs
 wget -nc -i brca_data_urls.txt '--directory-prefix='$data
 
-# modify BRCA clinical file column PAM50 to be subtype
-sed -i 's/PAM50/subtype/' $data/BRCAClin.tsv
-
 # Obtain TCGA data freeze manifest file
 # See here for more info: https://gdc.cancer.gov/about-data/publications/pancanatlas
 manifest_url="https://gdc.cancer.gov/files/public/file/PanCan-General_Open_GDC-Manifest_2.txt"
@@ -79,6 +76,9 @@ fi
 echo Checking md5 sums of downloaded files ...
 md5sum --check check_sums.tsv
 echo All files downloaded match expected md5 sums!
+
+# modify BRCA clinical file column PAM50 to be subtype
+sed -i 's/PAM50/subtype/' $data/BRCAClin.tsv
 
 # process GBM data via script
 echo Processing GBM data using R script prepare_GBM_data.R ...

--- a/download_TCGA_data.sh
+++ b/download_TCGA_data.sh
@@ -131,4 +131,3 @@ Rscript combine_clinical_data.R \
 #  gdc-client download --manifest gdc_legacy_archive_brca_manifest.txt --dir $brca_array_dir
 #fi
 ################################################################################
-

--- a/download_TCGA_data.sh
+++ b/download_TCGA_data.sh
@@ -81,7 +81,7 @@ echo All files downloaded match expected md5 sums!
 sed -i 's/PAM50/subtype/' $data/BRCAClin.tsv
 
 # process GBM data via script
-echo Processing GBM data using R script prepare_GBM_data.R ...
+echo Processing GBM data ...
 Rscript prepare_GBM_data.R \
   --seq_input $data/EBPlusPlusAdjustPANCAN_IlluminaHiSeq_RNASeqV2.geneExp.tsv \
   --array_input $data/GSE83130/GSE83130/GSE83130.tsv \

--- a/download_TCGA_data.sh
+++ b/download_TCGA_data.sh
@@ -93,17 +93,17 @@ Rscript prepare_GBM_data.R \
 
 # retrieve BRCA and GBM mutations in PIK3CA and TP53 from TCGA MC3
 # output is stored in data/mutations.* TSV and MAF files
-echo Retrieving mutation data from MC3 for BRCA and GBM...
+echo Retrieving mutation data from MC3 for BRCA and GBM ...
 python3 retrieve_MC3_mutations.py
 
 # combine clinical and mutation data into one data frame
-echo Combining clinical and mutation data for BRCA...
+echo Combining clinical and mutation data for BRCA ...
 Rscript combine_clinical_data.R \
   --cancer_type BRCA \
   --clinical_input $data/BRCAClin.tsv \
   --mutation_input $data/mutations.BRCA.tsv \
   --combined_output $data/combined_clinical_data.BRCA.tsv
-echo Combining clinical and mutation data for GBM...
+echo Combining clinical and mutation data for GBM ...
 Rscript combine_clinical_data.R \
   --cancer_type GBM \
   --clinical_input $data/GBMClin.tsv \


### PR DESCRIPTION
Closes #67 

This PR makes a necessary adjustment to the order of events in `download_TCGA_data.sh`. Modification to the column names of `data/BRCAClin.tsv` (previously merged) must come _after_ we do the `md5sum -- checksum`.

Otherwise, this PR
- eliminates the screen output from reading in clinical files in `combine_clinical_data.R` called from `download_TCGA_data.sh` by treating all column types the same (as character) WLOG
- slightly reformats informative screen output that give updates on the script's progress (simplifies here, adds a space there)

Thank you!