### PR TITLE
Envest/68 deg script file names

### DIFF
--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -51,24 +51,24 @@ norm.dir <- here::here("normalized_data")
 deg.dir <- file.path(res.dir, "differential_expression")
 
 # define input files
-seq.file <- file.path(data.dir, paste0(cancer_type, "RNASeq_matchedOnly_ordered.pcl"))
-array.file <- file.path(data.dir, paste0(cancer_type, "array_matchedOnly_ordered.pcl"))
+seq.file <- file.path(data.dir, paste0(file_identifier, "RNASeq_matchedOnly_ordered.pcl"))
+array.file <- file.path(data.dir, paste0(file_identifier, "array_matchedOnly_ordered.pcl"))
 smpl.file <- file.path(res.dir,
                        list.files(res.dir, # this finds the first example of a subtypes file from cancer_type
-                                  pattern = paste0(cancer_type, # and does not rely on knowing a seed
+                                  pattern = paste0(file_identifier, # and does not rely on knowing a seed
                                                    "_matchedSamples_subtypes_training_testing_split_labels_"))[1])
 
 # define output files
 subtype_vs_others.rds <- file.path(deg.dir,
-                                   paste0(cancer_type,
+                                   paste0(file_identifier,
                                           "_titration_differential_exp_eBayes_fits_",
                                           subtype_vs_others, "vOther.RDS"))
 two_subtypes.rds <- file.path(deg.dir,
-                              paste0(cancer_type,
+                              paste0(file_identifier,
                                      "_titration_differential_exp_eBayes_fits_",
                                      stringr::str_c(two_subtypes, collapse = "v"), ".RDS"))
 norm.rds <- file.path(norm.dir,
-                      paste0(cancer_type, "_titration_no_ZTO_transform_with_UN.RDS"))
+                      paste0(file_identifier, "_titration_no_ZTO_transform_with_UN.RDS"))
 
 #### read in data --------------------------------------------------------------
 

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -80,7 +80,7 @@ sample.df <- read.delim(smpl.file)
 
 # check that subtypes are in sample.df
 for(subtype in c(subtype_vs_others, two_subtypes)) {
-  if (!(subtype %in% sample.df$subtype)) {
+  if (!(subtype %in% sample.df$category)) {
     stop(paste("Subtype", subtype, "not found in sample file",
                smpl.file, "in 1A-detect_differentially_expressed_genes.R."))
   }

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -51,8 +51,10 @@ norm.dir <- here::here("normalized_data")
 deg.dir <- file.path(res.dir, "differential_expression")
 
 # define input files
-seq.file <- file.path(data.dir, paste0(file_identifier, "RNASeq_matchedOnly_ordered.pcl"))
-array.file <- file.path(data.dir, paste0(file_identifier, "array_matchedOnly_ordered.pcl"))
+seq.file <- file.path(data.dir,
+                      paste0(cancer_type, "RNASeq_matchedOnly_ordered.pcl"))
+array.file <- file.path(data.dir,
+                        paste0(cancer_type, "array_matchedOnly_ordered.pcl"))
 smpl.file <- file.path(res.dir,
                        list.files(res.dir, # this finds the first example of a subtypes file from cancer_type
                                   pattern = paste0(file_identifier, # and does not rely on knowing a seed

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -56,7 +56,7 @@ array.file <- file.path(data.dir, paste0(file_identifier, "array_matchedOnly_ord
 smpl.file <- file.path(res.dir,
                        list.files(res.dir, # this finds the first example of a subtypes file from cancer_type
                                   pattern = paste0(file_identifier, # and does not rely on knowing a seed
-                                                   "_matchedSamples_subtypes_training_testing_split_labels_"))[1])
+                                                   "_matchedSamples_training_testing_split_labels_"))[1])
 
 # define output files
 subtype_vs_others.rds <- file.path(deg.dir,

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -183,7 +183,7 @@ saveRDS(fit.results.list, file = subtype_vs_others.rds)
 #### Subtype v. Subtype --------------------------------------------------------
 # remove all samples that are not in these subtypes
 samples.to.keep <-
-  sample.df$sample[which(sample.df$subtype %in% two_subtypes)]
+  sample.df$sample[which(sample.df$category %in% two_subtypes)]
 
 pruned.norm.list <-
   lapply(norm.titrate.list,

--- a/1A-detect_differentially_expressed_genes.R
+++ b/1A-detect_differentially_expressed_genes.R
@@ -37,6 +37,7 @@ cancer_type <- opt$cancer_type
 subtype_vs_others <- opt$subtype_vs_others
 subtype_vs_subtype <- opt$subtype_vs_subtype
 two_subtypes <- as.vector(stringr::str_split(subtype_vs_subtype, pattern = ",", simplify = TRUE))
+file_identifier <- str_c(cancer_type, "subtype", sep = "_") # we are only working with subtype models here
 
 # set seed
 initial.seed <- opt$seed

--- a/2A-plot_DE_results.R
+++ b/2A-plot_DE_results.R
@@ -32,6 +32,7 @@ cancer_type <- opt$cancer_type
 subtype_vs_others <- opt$subtype_vs_others
 subtype_vs_subtype <- opt$subtype_vs_subtype
 two_subtypes <- as.vector(stringr::str_split(subtype_vs_subtype, pattern = ",", simplify = TRUE))
+file_identifier <- str_c(cancer_type, "subtype", sep = "_") # we are only working with subtype models here
 
 # define directories
 res.dir <- here::here("results")

--- a/2A-plot_DE_results.R
+++ b/2A-plot_DE_results.R
@@ -24,7 +24,7 @@ source(here::here("util/option_functions.R"))
 check_options(opt)
 
 # load libraries
-suppressMessages(library(ggplot2))
+suppressMessages(source(here::here("load_packages.R")))
 source(here::here("util", "differential_expression_functions.R"))
 
 # set options

--- a/2A-plot_DE_results.R
+++ b/2A-plot_DE_results.R
@@ -42,13 +42,13 @@ plots.dir <- here::here("plots")
 
 # subtype v. other fit objects
 subtype_vs_others.fit.list <- readRDS(file.path(res.dir, "differential_expression",
-                                                paste0(cancer_type, "_titration_differential_exp_eBayes_fits_",
+                                                paste0(file_identifier, "_titration_differential_exp_eBayes_fits_",
                                                        subtype_vs_others, "vOther.RDS")))
 
 # plot proportion of genes that are diff expressed and get topTable(s)
 subtype_vs_others.results <- PlotProportionDE(subtype_vs_others.fit.list)
 ggsave(file.path(plots.dir,
-                 paste0(cancer_type, "_differential_expr_proportion_ltFDR5perc_",
+                 paste0(file_identifier, "_differential_expr_proportion_ltFDR5perc_",
                         subtype_vs_others, "vOther.pdf")),
        plot = subtype_vs_others.results$plot, width = 11, height = 4.25)
 
@@ -64,13 +64,13 @@ subtypes_combination_nice <- stringr::str_c(two_subtypes, collapse = " vs. ")
 
 last_subtype.fit.list <- readRDS(file.path(
   res.dir, "differential_expression",
-  paste0(cancer_type, "_titration_differential_exp_eBayes_fits_",
+  paste0(file_identifier, "_titration_differential_exp_eBayes_fits_",
          subtypes_combination, ".RDS")))
 
 # plot proportion of genes that are diff expressed and get topTable(s)
 last_subtype.results <- PlotProportionDE(last_subtype.fit.list)
 ggsave(file.path(plots.dir,
-                 paste0(cancer_type, "_differential_expr_proportion_ltFDR5perc_",
+                 paste0(file_identifier, "_differential_expr_proportion_ltFDR5perc_",
                         subtypes_combination, ".pdf")),
        plot = last_subtype.results$plot, width = 11, height = 4.25)
 

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -32,6 +32,7 @@ source(here::here("util", "color_blind_friendly_palette.R"))
 cancer_type <- opt$cancer_type
 subtype_vs_subtype <- opt$subtype_vs_subtype
 two_subtypes <- as.vector(stringr::str_split(subtype_vs_subtype, pattern = ",", simplify = TRUE))
+file_identifier <- str_c(cancer_type, "subtype", sep = "_") # we are only working with subtype models here
 
 # set seed
 initial.seed <- opt$seed

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -77,7 +77,7 @@ sample.df <- read.delim(smpl.file)
 
 # check that subtypes are in sample.df
 for(subtype in two_subtypes) {
-  if (!(subtype %in% sample.df$subtype)) {
+  if (!(subtype %in% sample.df$category)) {
     stop(paste("Subtype", subtype, "not found in sample file",
                smpl.file, "in 3A-small_n_differential_expression.R."))
   }
@@ -90,7 +90,7 @@ sample.names <- sample.df$sample
 # leave only subtypes of interest to choose from & make data.table
 # remove all samples that are not subtypes of interest
 samples.to.keep <-
-  sample.df$sample[which(sample.df$subtype %in% two_subtypes)]
+  sample.df$sample[which(sample.df$category %in% two_subtypes)]
 
 array.dt <- data.table(array.data[,
                                   c(1, which(colnames(array.data) %in%
@@ -100,7 +100,7 @@ seq.dt <- data.table(seq.data[,
                                            samples.to.keep))])
 sample.df <- sample.df[which(sample.df$sample %in% samples.to.keep), ]
 
-smaller_subtype_size <- min(table(droplevels(sample.df$subtype)))
+smaller_subtype_size <- min(table(droplevels(sample.df$category)))
 
 # different sizes of n to test
 no.samples <- c(3, 4, 5, 6, 8, 10, 15, 25, 50)

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -47,12 +47,12 @@ deg.dir <- file.path(res.dir, "differential_expression")
 
 # define input files
 seq.file <- file.path(data.dir,
-                      paste0(cancer_type, "RNASeq_matchedOnly_ordered.pcl"))
+                      paste0(file_identifier, "RNASeq_matchedOnly_ordered.pcl"))
 array.file <- file.path(data.dir,
-                        paste0(cancer_type, "array_matchedOnly_ordered.pcl"))
+                        paste0(file_identifier, "array_matchedOnly_ordered.pcl"))
 smpl.file <- file.path(res.dir,
                        list.files(res.dir, # this finds the first example of a subtypes file from cancer_type
-                                  pattern = paste0(cancer_type, # and does not rely on knowing a seed
+                                  pattern = paste0(file_identifier, # and does not rely on knowing a seed
                                                    "_matchedSamples_subtypes_training_testing_split_labels_"))[1])
 
 #### functions -----------------------------------------------------------------
@@ -157,7 +157,7 @@ jacc.df <- data.table::rbindlist(jacc.df.list)
 
 write.table(jacc.df,
             file = file.path(deg.dir,
-                             paste0(cancer_type,
+                             paste0(file_identifier,
                                     "_small_n_",
                                     subtypes_combination,
                                     "_50-50_jaccard_results.tsv")),
@@ -177,5 +177,5 @@ ggplot(jacc.df, aes(x = no.samples, y = jaccard, color = platform)) +
   scale_colour_manual(values = cbPalette[c(2, 3)]) +
   theme(text = element_text(size = 18))
 ggsave(filename = here::here("plots",
-                             paste0(cancer_type, "_small_n_", subtypes_combination, "_50-50_jaccard_lineplots.pdf")),
+                             paste0(file_identifier, "_small_n_", subtypes_combination, "_50-50_jaccard_lineplots.pdf")),
        plot = last_plot(), width = 5, height = 7)

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -47,7 +47,7 @@ deg.dir <- file.path(res.dir, "differential_expression")
 
 # define input files
 seq.file <- file.path(data.dir,
-                      paste0(cancer_typer, "RNASeq_matchedOnly_ordered.pcl"))
+                      paste0(cancer_type, "RNASeq_matchedOnly_ordered.pcl"))
 array.file <- file.path(data.dir,
                         paste0(cancer_type, "array_matchedOnly_ordered.pcl"))
 smpl.file <- file.path(res.dir,

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -47,9 +47,9 @@ deg.dir <- file.path(res.dir, "differential_expression")
 
 # define input files
 seq.file <- file.path(data.dir,
-                      paste0(file_identifier, "RNASeq_matchedOnly_ordered.pcl"))
+                      paste0(cancer_typer, "RNASeq_matchedOnly_ordered.pcl"))
 array.file <- file.path(data.dir,
-                        paste0(file_identifier, "array_matchedOnly_ordered.pcl"))
+                        paste0(cancer_type, "array_matchedOnly_ordered.pcl"))
 smpl.file <- file.path(res.dir,
                        list.files(res.dir, # this finds the first example of a subtypes file from cancer_type
                                   pattern = paste0(file_identifier, # and does not rely on knowing a seed

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -53,7 +53,7 @@ array.file <- file.path(data.dir,
 smpl.file <- file.path(res.dir,
                        list.files(res.dir, # this finds the first example of a subtypes file from cancer_type
                                   pattern = paste0(file_identifier, # and does not rely on knowing a seed
-                                                   "_matchedSamples_subtypes_training_testing_split_labels_"))[1])
+                                                   "_matchedSamples_training_testing_split_labels_"))[1])
 
 #### functions -----------------------------------------------------------------
 

--- a/run_differential_expression_experiments.sh
+++ b/run_differential_expression_experiments.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -euo pipefail
 
-# Usage: bash run_differential_expression_experiments.sh CANCER_TYPE SUBTYPE_VS_OTHERS SUBTYPE_VS_SUBTYPE
+# Usage: bash run_differential_expression_experiments.sh CANCER_TYPE SUBTYPE_VS_OTHERS SUBTYPE_VS_SUBTYPE SUBTYPE_VS_SUBTYPE_SMALL
 # where CANCER_TYPE is one of BRCA or GBM
 # SUBTYPE_VS_OTHER is the subtype you want to compare to all others (e.g. Basal)
 # SUBTYPE_VS_SUBTYPE is the two subtypes you want to compare head to head (e.g. LumA,Her2) (comma-separated)
@@ -13,11 +13,11 @@ subtype_vs_subtype=$3
 subtype_vs_subytpe_small=$4
 
 if [ $cancer_type != "BRCA" ] && [ $cancer_type != "GBM" ]; then
-  echo Cancer type must be BRCA or GBM in run_machine_learning_experiments.sh [cancer_type]
+  echo Cancer type must be BRCA or GBM in run_differential_expression_experiments.sh [cancer_type]
   exit
 fi
 
 # Run differential expression scripts
-Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type --subtype_vs_others $2 --subtype_vs_subtype $3
-Rscript 2A-plot_DE_results.R --cancer_type $cancer_type --subtype_vs_others $2 --subtype_vs_subtype $3
-Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --subtype_vs_subtype $4
+Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type --subtype_vs_others $subtype_vs_others --subtype_vs_subtype $subtype_vs_subtype
+Rscript 2A-plot_DE_results.R --cancer_type $cancer_type --subtype_vs_others $subtype_vs_others --subtype_vs_subtype $subtype_vs_subtype
+Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --subtype_vs_subtype $subtype_vs_subtype_small

--- a/run_differential_expression_experiments.sh
+++ b/run_differential_expression_experiments.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 cancer_type=$1
 subtype_vs_others=$2
 subtype_vs_subtype=$3
-subtype_vs_subytpe_small=$4
+subtype_vs_subtype_small=$4
 
 if [ $cancer_type != "BRCA" ] && [ $cancer_type != "GBM" ]; then
   echo Cancer type must be BRCA or GBM in run_differential_expression_experiments.sh [cancer_type]

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -21,15 +21,15 @@ GetDesignMat <- function(norm.dt, sample.df, subtype) {
 
   # error-handling
   if (!("sample" %in% colnames(sample.df)
-        & "subtype" %in% colnames(sample.df))) {
-    stop("sample.df must have columns named sample and subtype")
+        & "category" %in% colnames(sample.df))) {
+    stop("sample.df must have columns named sample and category")
   }
 
   # get a factor vector of labels, ordered to match the columns of
   # norm.dt
   group.factor <-
-    as.character(GetOrderedSubtypeLabels(norm.dt,
-                                         sample.df))
+    as.character(GetOrderedCategoryLabels(norm.dt,
+                                          sample.df))
   group.factor[which(group.factor != subtype)] <- "Other"
   group.factor <- as.factor(group.factor)
 
@@ -458,8 +458,8 @@ SmallNDEGWrapper <- function(norm.list, sample.df, subtype) {
   #
   # error-handling
   if (!("sample" %in% colnames(sample.df)
-        & "subtype" %in% colnames(sample.df))) {
-    stop("sample.df must have columns named sample and subtype")
+        & "category" %in% colnames(sample.df))) {
+    stop("sample.df must have columns named sample and category")
   }
 
   full.design.mat <- GetDesignMat(norm.list$log, sample.df, subtype)
@@ -506,13 +506,13 @@ GetSamplesforMixingSmallN <- function(n, sample.df, subtype) {
   # get samples from the subtype of interest
   subtype.samples <-
     as.character(
-      sample.df$sample[sample(which(sample.df$subtype == subtype), n)]
+      sample.df$sample[sample(which(sample.df$category == subtype), n)]
     )
 
   # get comparator group samples
   other.samples <-
     as.character(
-      sample.df$sample[sample(which(sample.df$subtype != subtype), n)]
+      sample.df$sample[sample(which(sample.df$category != subtype), n)]
     )
 
   # all samples


### PR DESCRIPTION
Closes #68 

This PR updates the DEG scripts in two main ways:
- Uses `file_identifier` (`cancer_type` + "subtype") instead of `cancer_type` to define file names
- Replaces "subtype" with "category" when appropriate, in comments and referring to sample data frame column names

We are now up to date! Thanks!