### PR TITLE
Envest/75 deg metrics

### DIFF
--- a/2A-plot_DE_results.R
+++ b/2A-plot_DE_results.R
@@ -52,11 +52,16 @@ ggsave(file.path(plots.dir,
                         subtype_vs_others, "vOther.pdf")),
        plot = subtype_vs_others.results$plot, width = 11, height = 4.25)
 
-# plot jaccard similarity with silver standards
-subtype_vs_others.jacc.plot <- PlotSilverStandardJaccard(subtype_vs_others.results$top.table.list,
-                                                         title = paste(subtype_vs_others, "v. Other FDR < 5%"))
-ggsave(file.path(plots.dir, paste0(subtype_vs_others, "_v_other_jaccard_lineplot.pdf")),
-       plot = subtype_vs_others.jacc.plot, width = 8.5, height = 4)
+# plot jaccard similarity, rand index, and spearman correlation with silver standards
+subtype_vs_others.plots <- PlotSilverStandardStats(subtype_vs_others.results$top.table.list,
+                                                   title = paste(subtype_vs_others, "v. Other FDR < 5%"))
+
+ggsave(file.path(plots.dir, paste0(subtypes_combination, "_jaccard_lineplot.pdf")),
+       plot = subtype_vs_others.plots$jaccard, width = 8.5, height = 4)
+ggsave(file.path(plots.dir, paste0(subtypes_combination, "_rand_lineplot.pdf")),
+       plot = subtype_vs_others.plots$rand, width = 8.5, height = 4)
+ggsave(file.path(plots.dir, paste0(subtypes_combination, "_spearman_lineplot.pdf")),
+       plot = subtype_vs_others.plots$spearman, width = 8.5, height = 4)
 
 #### plot Subtype v. Subtype results --------------------------------------------
 subtypes_combination <- stringr::str_c(two_subtypes, collapse = "v")
@@ -74,8 +79,13 @@ ggsave(file.path(plots.dir,
                         subtypes_combination, ".pdf")),
        plot = last_subtype.results$plot, width = 11, height = 4.25)
 
-# plot jaccard similarity with silver standards
-last_subtype.jacc.plot <- PlotSilverStandardJaccard(last_subtype.results$top.table.list,
-                                                    title = paste(subtypes_combination_nice, "FDR < 5%"))
+# plot jaccard similarity, rand index, and spearman correlation with silver standards
+last_subtype.plots <- PlotSilverStandardStats(last_subtype.results$top.table.list,
+                                              title = paste(subtypes_combination_nice, "FDR < 5%"))
+
 ggsave(file.path(plots.dir, paste0(subtypes_combination, "_jaccard_lineplot.pdf")),
-       plot = last_subtype.jacc.plot, width = 8.5, height = 4)
+       plot = last_subtype.plots$jaccard, width = 8.5, height = 4)
+ggsave(file.path(plots.dir, paste0(subtypes_combination, "_rand_lineplot.pdf")),
+       plot = last_subtype.plots$rand, width = 8.5, height = 4)
+ggsave(file.path(plots.dir, paste0(subtypes_combination, "_spearman_lineplot.pdf")),
+       plot = last_subtype.plots$spearman, width = 8.5, height = 4)

--- a/2A-plot_DE_results.R
+++ b/2A-plot_DE_results.R
@@ -56,13 +56,13 @@ ggsave(file.path(plots.dir,
 subtype_vs_others.plots <- PlotSilverStandardStats(subtype_vs_others.results$top.table.list,
                                                    title = paste(subtype_vs_others, "v. Other FDR < 5%"))
 
-ggsave(file.path(plots.dir, paste0(subtypes_combination,
+ggsave(file.path(plots.dir, paste0(subtype_vs_others,
                                    "_vOthers_jaccard_lineplot.pdf")),
        plot = subtype_vs_others.plots$jaccard, width = 8.5, height = 4)
-ggsave(file.path(plots.dir, paste0(subtypes_combination,
+ggsave(file.path(plots.dir, paste0(subtype_vs_others,
                                    "_vOthers_rand_lineplot.pdf")),
        plot = subtype_vs_others.plots$rand, width = 8.5, height = 4)
-ggsave(file.path(plots.dir, paste0(subtypes_combination,
+ggsave(file.path(plots.dir, paste0(subtype_vs_others,
                                    "_vOthers_spearman_lineplot.pdf")),
        plot = subtype_vs_others.plots$spearman, width = 8.5, height = 4)
 

--- a/2A-plot_DE_results.R
+++ b/2A-plot_DE_results.R
@@ -56,11 +56,14 @@ ggsave(file.path(plots.dir,
 subtype_vs_others.plots <- PlotSilverStandardStats(subtype_vs_others.results$top.table.list,
                                                    title = paste(subtype_vs_others, "v. Other FDR < 5%"))
 
-ggsave(file.path(plots.dir, paste0(subtypes_combination, "_jaccard_lineplot.pdf")),
+ggsave(file.path(plots.dir, paste0(subtypes_combination,
+                                   "_vOthers_jaccard_lineplot.pdf")),
        plot = subtype_vs_others.plots$jaccard, width = 8.5, height = 4)
-ggsave(file.path(plots.dir, paste0(subtypes_combination, "_rand_lineplot.pdf")),
+ggsave(file.path(plots.dir, paste0(subtypes_combination,
+                                   "_vOthers_rand_lineplot.pdf")),
        plot = subtype_vs_others.plots$rand, width = 8.5, height = 4)
-ggsave(file.path(plots.dir, paste0(subtypes_combination, "_spearman_lineplot.pdf")),
+ggsave(file.path(plots.dir, paste0(subtypes_combination,
+                                   "_vOthers_spearman_lineplot.pdf")),
        plot = subtype_vs_others.plots$spearman, width = 8.5, height = 4)
 
 #### plot Subtype v. Subtype results --------------------------------------------

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -283,7 +283,7 @@ GetGeneSetStats <- function(silver.set,
               by = "gene")
   
   # calculate agreement between two results
-  contingency_table <- combined_df %>%
+  contingency_table <- combine_df %>%
     select(silver_group,
            experimental_group) %>%
     table()
@@ -723,7 +723,7 @@ SmallNDEGWrapper <- function(norm.list, sample.df, subtype) {
 
 }
 
-GetSamplesforMixingSmallN <- function(n, sample.df, subtype, seq_proportion) {
+GetSamplesforMixingSmallN <- function(n, sample.df, subtype) {
   # This function is designed to identify sample names to be used in the "small
   # n" differential expression experiment
   #
@@ -731,7 +731,6 @@ GetSamplesforMixingSmallN <- function(n, sample.df, subtype, seq_proportion) {
   #   n: number of samples (for each subtype - no. of replicates)
   #   sample.df: a data.frame mapping sample names to subtype labels
   #   subtype: which subtype should be compared to all others
-  #   seq_proportion: percentage of RNA-seq samples to include in mix
   #
   # Returns:
   #   A list comprised of the following:
@@ -756,8 +755,8 @@ GetSamplesforMixingSmallN <- function(n, sample.df, subtype, seq_proportion) {
   # all samples
   all.samples <- c(subtype.samples, other.samples)
   # array half
-  array.samples <- c(sample(subtype.samples, floor(n * (1 - seq_proportion))),
-                     sample(other.samples, ceiling(n * (1 - seq_proportion))))
+  array.samples <- c(sample(subtype.samples, floor(n * .5)),
+                     sample(other.samples, ceiling(n * .5)))
   # seq half
   seq.samples <- all.samples[!(all.samples %in% array.samples)]
 
@@ -802,7 +801,7 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
                                            mix.list$all)), with = FALSE]
   seq.full.dt  <- seq.dt[, c(1, which(colnames(seq.dt) %in%
                                         mix.list$all)), with = FALSE]
-  
+
   # array and seq data.tables to be used in the 50-50 experiment
   array.half.dt <- array.dt[, c(1, which(colnames(array.dt) %in%
                                            mix.list$array)), with = FALSE]

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -283,7 +283,7 @@ GetGeneSetStats <- function(silver.set,
               by = "gene")
   
   # calculate agreement between two results
-  contingency_table <- combine_df %>%
+  contingency_table <- combined_df %>%
     select(silver_group,
            experimental_group) %>%
     table()

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -300,7 +300,9 @@ GetGeneSetStats <- function(silver.set,
                                  method = "spearman",
                                  exact = FALSE,
                                  continuity = TRUE)$estimate)
-  return(c(jacc, rand, spearman))
+  return(data.frame(jaccard_similarity = jacc,
+                    rand_index = rand,
+                    spearman_rho = spearman))
 }
 
 

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -300,9 +300,9 @@ GetGeneSetStats <- function(silver.set,
                                  method = "spearman",
                                  exact = FALSE,
                                  continuity = TRUE)$estimate)
-  return(data.frame(jaccard_similarity = jacc,
-                    rand_index = rand,
-                    spearman_rho = spearman))
+  return(data.frame("jaccard" = jacc,
+                    "rand" = rand,
+                    "spearman" = spearman))
 }
 
 

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -213,33 +213,6 @@ GetAllGenesTopTable <- function(fit.object, adjust = "BH") {
   return(top.table)
 }
 
-GetGeneSetJaccard <- function(silver.set, top.table,
-                              cutoff = 0.05) {
-  # Given a "silver standard" of differentially expressed genes (a character
-  # vector), find the Jaccard similarity between the silver standard and another
-  # set of differentially expressed genes (DEGs; from limma::topTable output)
-  # using a user-specified adjusted p-value threshold
-  #
-  # Args:
-  #   silver.set: a character vector of the "silver standard" genes
-  #   top.table: output of limma::topTable (typically from GetAllGenesTopTable)
-  #              for the other differential expression experiment being
-  #              considered
-  #   cutoff: the adjusted p-value threshold - all genes with an adjusted p
-  #           below this threshold will be considered differentially expressed
-  #
-  # Returns:
-  #   jacc: Jaccard similarity of silver standard and other set of DEGs
-
-  # get differentially expressed gene set from experiment topTable
-  tt.set <- rownames(top.table)[which(top.table$adj.P.Val < cutoff)]
-  # find Jaccard similarity between experiment and silver standard
-  jacc <-
-    length(intersect(silver.set, tt.set)) / length(union(silver.set, tt.set))
-  # return Jaccard similarity
-  return(jacc)
-}
-
 GetGeneSetStats <- function(silver.set,
                            top.table,
                            cutoff = 0.05) {
@@ -365,77 +338,6 @@ PlotProportionDE <- function(fit.list, adjust.method = "BH", cutoff = 0.05) {
   return(list("top.table.list" = top.table.list, "plot" = p))
 }
 
-PlotSilverStandardJaccard <- function(top.table.list, title,
-                                      cutoff = 0.05){
-  # Given a list of top tables, plot the Jaccard similarity between the
-  # microarray and RNA-seq "silver standards" and all other experiments
-  #
-  # Args:
-  #   top.table.list: list of limma::topTable objects from PlotProportionDE
-  #   title: a character vector to be used for the title of the plot
-  #   cutoff: adjusted p-value threshold to be used
-  #
-  # Returns:
-  #   p: Jaccard similarity line plot
-  #
-
-  ### "silver standards" ###
-
-  # 100% RNA-seq data RSEM using limma::voom processing step
-  seq.truth.set <-
-    rownames(top.table.list$`100`$un)[which(top.table.list$`100`$un$adj.P.Val <
-                                              cutoff)]
-  # LOG 100% array data
-  array.truth.set <-
-    rownames(top.table.list$`0`$log)[which(top.table.list$`0`$log$adj.P.Val <
-                                             cutoff)]
-
-  # how similiar are DEG results to the RNA-seq silver standard? as data.frame
-  seq.jacc.list <-
-    lapply(top.table.list,
-           function(x) lapply(x,
-                              function(y) GetGeneSetJaccard(seq.truth.set, y)))
-  seq.jacc.df <- reshape2::melt(seq.jacc.list)
-
-  # how similiar are DEG results to the microarray silver standard? as data.frame
-  array.jacc.list <-
-    lapply(top.table.list,
-           function(x) lapply(x,
-                              function(y) GetGeneSetJaccard(array.truth.set,
-                                                            y)))
-  array.jacc.df <- reshape2::melt(array.jacc.list)
-
-  # combine seq and array similarity results
-  array.jacc.df <- cbind(array.jacc.df, rep("Microarray", nrow(array.jacc.df)))
-  seq.jacc.df <- cbind(seq.jacc.df, rep("RNA-seq", nrow(seq.jacc.df)))
-  colnames(seq.jacc.df) <- colnames(array.jacc.df) <- c("jaccard",
-                                                        "normalization",
-                                                        "perc.seq",
-                                                        "platform")
-  mstr.df <- rbind(array.jacc.df, seq.jacc.df)
-
-  # order % seq so plot displays 0-100
-  mstr.df$perc.seq <- factor(mstr.df$perc.seq, levels = seq(0, 100, 10))
-
-  # capitalize normalization methods for display
-  mstr.df$normalization <- as.factor(toupper(mstr.df$normalization))
-
-  # line plot
-  p <- ggplot(mstr.df, aes(perc.seq, jaccard,
-                           color = platform, fill = platform)) +
-    facet_wrap(~normalization, ncol = 4) +
-    geom_line(aes(group = platform), position = position_dodge(0.3)) +
-    geom_point(aes(group = platform), position = position_dodge(0.3)) +
-    theme_bw() +
-    scale_colour_manual(values = cbPalette[c(2, 3)]) +
-    ggtitle(title) +
-    xlab("% RNA-seq") +
-    ylab("Jaccard similarity") +
-    theme(axis.text.x=element_text(angle = 45, vjust = 0.5))
-  return(p)
-
-}
-
 PlotSilverStandardStats <- function(top.table.list, title,
                                     cutoff = 0.05){
   # Given a list of top tables, plot the Jaccard similarity, Rand index, and
@@ -542,78 +444,6 @@ PlotSilverStandardStats <- function(top.table.list, title,
 }
 
 #### small n functions ---------------------------------------------------------
-
-GetSmallNSilverStandardJaccard <- function(top.table.list, cutoff = 0.05){
-  # This function takes a list of limma::topTable output, derives "silver
-  # standards" from 100% array and 100% seq data, and finds the Jaccard
-  # similarity between the standards and 50-50 experiment differential
-  # expression results (quantile norm and z-score)
-  #
-  # Args:
-  #   top.table.list: a list of limma::topTable output with all genes -
-  #                   output of GetAllGenesTopTable
-  #   cutoff: FDR cutoff, defaults to FDR < 5%
-  #
-  # Returns:
-  #   jacc.df: a data.frame of the Jaccard results with columns corresponding to
-  #            the Jaccard value, the silver standard used for the
-  #            comparison ("platform"), the normalization method, and the
-  #            n used (number of samples; "no.samples")
-  #
-
-  # initialize list to hold Jaccard similarity
-  jacc.list <- list()
-
-  # for each n (number of samples)
-  for (smpl.no.iter in seq_along(top.table.list)) {
-
-    current.smpl.tt <- top.table.list[[smpl.no.iter]]
-    current.n <- names(top.table.list)[smpl.no.iter]
-
-    array.top <- current.smpl.tt$log
-    array.standard <- rownames(array.top)[which(array.top$adj.P.Val < cutoff)]
-    seq.top <- current.smpl.tt$un
-    seq.standard <- rownames(seq.top)[which(seq.top$adj.P.Val < cutoff)]
-
-    jacc.list[[current.n]]$qn$array <-
-      GetGeneSetJaccard(array.standard,
-                        top.table = current.smpl.tt$qn,
-                        cutoff)
-    jacc.list[[current.n]]$qn$seq <-
-      GetGeneSetJaccard(seq.standard,
-                        top.table = current.smpl.tt$qn,
-                        cutoff)
-    jacc.list[[current.n]]$z$array <-
-      GetGeneSetJaccard(array.standard,
-                        top.table = current.smpl.tt$z,
-                        cutoff)
-    jacc.list[[current.n]]$z$seq <-
-      GetGeneSetJaccard(seq.standard,
-                        top.table = current.smpl.tt$z,
-                        cutoff)
-
-  }
-
-  jacc.df <- reshape2::melt(jacc.list)
-  colnames(jacc.df) <-c("jaccard", "platform", "normalization", "no.samples")
-
-  # rename platforms
-  plt.recode.str <-
-    "'array' = 'Microarray'; 'seq' = 'RNA-seq'"
-  jacc.df$platform <- car::recode(jacc.df$platform,
-                                  recodes = plt.recode.str)
-
-  # order no.samples so plot displays from smallest n to largest
-  jacc.df$no.samples <-
-    factor(jacc.df$no.samples,
-           levels = sort(unique(as.numeric(as.character(jacc.df$no.samples)))))
-
-  # capitalize normalization methods for display
-  jacc.df$normalization <- as.factor(toupper(jacc.df$normalization))
-
-  return(jacc.df)
-
-}
 
 GetSmallNSilverStandardStats <- function(top.table.list, cutoff = 0.05){
   # This function takes a list of limma::topTable output, derives "silver

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -213,33 +213,6 @@ GetAllGenesTopTable <- function(fit.object, adjust = "BH") {
   return(top.table)
 }
 
-GetGeneSetJaccard <- function(silver.set, top.table,
-                              cutoff = 0.05) {
-  # Given a "silver standard" of differentially expressed genes (a character
-  # vector), find the Jaccard similarity between the silver standard and another
-  # set of differentially expressed genes (DEGs; from limma::topTable output)
-  # using a user-specified adjusted p-value threshold
-  #
-  # Args:
-  #   silver.set: a character vector of the "silver standard" genes
-  #   top.table: output of limma::topTable (typically from GetAllGenesTopTable)
-  #              for the other differential expression experiment being
-  #              considered
-  #   cutoff: the adjusted p-value threshold - all genes with an adjusted p
-  #           below this threshold will be considered differentially expressed
-  #
-  # Returns:
-  #   jacc: Jaccard similarity of silver standard and other set of DEGs
-
-  # get differentially expressed gene set from experiment topTable
-  tt.set <- rownames(top.table)[which(top.table$adj.P.Val < cutoff)]
-  # find Jaccard similarity between experiment and silver standard
-  jacc <-
-    length(intersect(silver.set, tt.set)) / length(union(silver.set, tt.set))
-  # return Jaccard similarity
-  return(jacc)
-}
-
 GetGeneSetStats <- function(silver.set,
                            top.table,
                            cutoff = 0.05) {
@@ -369,77 +342,6 @@ PlotProportionDE <- function(fit.list, adjust.method = "BH", cutoff = 0.05) {
   return(list("top.table.list" = top.table.list, "plot" = p))
 }
 
-PlotSilverStandardJaccard <- function(top.table.list, title,
-                                      cutoff = 0.05){
-  # Given a list of top tables, plot the Jaccard similarity between the
-  # microarray and RNA-seq "silver standards" and all other experiments
-  #
-  # Args:
-  #   top.table.list: list of limma::topTable objects from PlotProportionDE
-  #   title: a character vector to be used for the title of the plot
-  #   cutoff: adjusted p-value threshold to be used
-  #
-  # Returns:
-  #   p: Jaccard similarity line plot
-  #
-
-  ### "silver standards" ###
-
-  # 100% RNA-seq data RSEM using limma::voom processing step
-  seq.truth.set <-
-    rownames(top.table.list$`100`$un)[which(top.table.list$`100`$un$adj.P.Val <
-                                              cutoff)]
-  # LOG 100% array data
-  array.truth.set <-
-    rownames(top.table.list$`0`$log)[which(top.table.list$`0`$log$adj.P.Val <
-                                             cutoff)]
-
-  # how similiar are DEG results to the RNA-seq silver standard? as data.frame
-  seq.jacc.list <-
-    lapply(top.table.list,
-           function(x) lapply(x,
-                              function(y) GetGeneSetJaccard(seq.truth.set, y)))
-  seq.jacc.df <- reshape2::melt(seq.jacc.list)
-
-  # how similiar are DEG results to the microarray silver standard? as data.frame
-  array.jacc.list <-
-    lapply(top.table.list,
-           function(x) lapply(x,
-                              function(y) GetGeneSetJaccard(array.truth.set,
-                                                            y)))
-  array.jacc.df <- reshape2::melt(array.jacc.list)
-
-  # combine seq and array similarity results
-  array.jacc.df <- cbind(array.jacc.df, rep("Microarray", nrow(array.jacc.df)))
-  seq.jacc.df <- cbind(seq.jacc.df, rep("RNA-seq", nrow(seq.jacc.df)))
-  colnames(seq.jacc.df) <- colnames(array.jacc.df) <- c("jaccard",
-                                                        "normalization",
-                                                        "perc.seq",
-                                                        "platform")
-  mstr.df <- rbind(array.jacc.df, seq.jacc.df)
-
-  # order % seq so plot displays 0-100
-  mstr.df$perc.seq <- factor(mstr.df$perc.seq, levels = seq(0, 100, 10))
-
-  # capitalize normalization methods for display
-  mstr.df$normalization <- as.factor(toupper(mstr.df$normalization))
-
-  # line plot
-  p <- ggplot(mstr.df, aes(perc.seq, jaccard,
-                           color = platform, fill = platform)) +
-    facet_wrap(~normalization, ncol = 4) +
-    geom_line(aes(group = platform), position = position_dodge(0.3)) +
-    geom_point(aes(group = platform), position = position_dodge(0.3)) +
-    theme_bw() +
-    scale_colour_manual(values = cbPalette[c(2, 3)]) +
-    ggtitle(title) +
-    xlab("% RNA-seq") +
-    ylab("Jaccard similarity") +
-    theme(axis.text.x=element_text(angle = 45, vjust = 0.5))
-  return(p)
-
-}
-
 PlotSilverStandardStats <- function(top.table.list, title,
                                     cutoff = 0.05){
   # Given a list of top tables, plot the Jaccard similarity, Rand index, and
@@ -546,78 +448,6 @@ PlotSilverStandardStats <- function(top.table.list, title,
 }
 
 #### small n functions ---------------------------------------------------------
-
-GetSmallNSilverStandardJaccard <- function(top.table.list, cutoff = 0.05){
-  # This function takes a list of limma::topTable output, derives "silver
-  # standards" from 100% array and 100% seq data, and finds the Jaccard
-  # similarity between the standards and titrated experiment differential
-  # expression results (quantile norm and z-score)
-  #
-  # Args:
-  #   top.table.list: a list of limma::topTable output with all genes -
-  #                   output of GetAllGenesTopTable
-  #   cutoff: FDR cutoff, defaults to FDR < 5%
-  #
-  # Returns:
-  #   jacc.df: a data.frame of the Jaccard results with columns corresponding to
-  #            the Jaccard value, the silver standard used for the
-  #            comparison ("platform"), the normalization method, and the
-  #            n used (number of samples; "no.samples")
-  #
-
-  # initialize list to hold Jaccard similarity
-  jacc.list <- list()
-
-  # for each n (number of samples)
-  for (smpl.no.iter in seq_along(top.table.list)) {
-
-    current.smpl.tt <- top.table.list[[smpl.no.iter]]
-    current.n <- names(top.table.list)[smpl.no.iter]
-
-    array.top <- current.smpl.tt$log
-    array.standard <- rownames(array.top)[which(array.top$adj.P.Val < cutoff)]
-    seq.top <- current.smpl.tt$un
-    seq.standard <- rownames(seq.top)[which(seq.top$adj.P.Val < cutoff)]
-
-    jacc.list[[current.n]]$qn$array <-
-      GetGeneSetJaccard(array.standard,
-                        top.table = current.smpl.tt$qn,
-                        cutoff)
-    jacc.list[[current.n]]$qn$seq <-
-      GetGeneSetJaccard(seq.standard,
-                        top.table = current.smpl.tt$qn,
-                        cutoff)
-    jacc.list[[current.n]]$z$array <-
-      GetGeneSetJaccard(array.standard,
-                        top.table = current.smpl.tt$z,
-                        cutoff)
-    jacc.list[[current.n]]$z$seq <-
-      GetGeneSetJaccard(seq.standard,
-                        top.table = current.smpl.tt$z,
-                        cutoff)
-
-  }
-
-  jacc.df <- reshape2::melt(jacc.list)
-  colnames(jacc.df) <-c("jaccard", "platform", "normalization", "no.samples")
-
-  # rename platforms
-  plt.recode.str <-
-    "'array' = 'Microarray'; 'seq' = 'RNA-seq'"
-  jacc.df$platform <- car::recode(jacc.df$platform,
-                                  recodes = plt.recode.str)
-
-  # order no.samples so plot displays from smallest n to largest
-  jacc.df$no.samples <-
-    factor(jacc.df$no.samples,
-           levels = sort(unique(as.numeric(as.character(jacc.df$no.samples)))))
-
-  # capitalize normalization methods for display
-  jacc.df$normalization <- as.factor(toupper(jacc.df$normalization))
-
-  return(jacc.df)
-
-}
 
 GetSmallNSilverStandardStats <- function(top.table.list, cutoff = 0.05){
   # This function takes a list of limma::topTable output, derives "silver

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -280,7 +280,9 @@ GetGeneSetStats <- function(silver.set,
   # join those data sets together to match up gene names
   combined_df <- silver_df %>%
     left_join(experimental_df,
-              by = "gene")
+              by = "gene") %>%
+    mutate(silver_group = factor(silver_group, levels = c(0, 1)),
+           experimental_group = factor(experimental_group, levels = c(0, 1)))
   
   # calculate agreement between two results
   contingency_table <- combined_df %>%

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -283,7 +283,7 @@ GetGeneSetStats <- function(silver.set,
               by = "gene")
   
   # calculate agreement between two results
-  contingency_table <- combine_df %>%
+  contingency_table <- combined_df %>%
     select(silver_group,
            experimental_group) %>%
     table()
@@ -723,7 +723,7 @@ SmallNDEGWrapper <- function(norm.list, sample.df, subtype) {
 
 }
 
-GetSamplesforMixingSmallN <- function(n, sample.df, subtype) {
+GetSamplesforMixingSmallN <- function(n, sample.df, subtype, seq_proportion) {
   # This function is designed to identify sample names to be used in the "small
   # n" differential expression experiment
   #
@@ -731,6 +731,7 @@ GetSamplesforMixingSmallN <- function(n, sample.df, subtype) {
   #   n: number of samples (for each subtype - no. of replicates)
   #   sample.df: a data.frame mapping sample names to subtype labels
   #   subtype: which subtype should be compared to all others
+  #   seq_proportion: percentage of RNA-seq samples to include in mix
   #
   # Returns:
   #   A list comprised of the following:
@@ -755,8 +756,8 @@ GetSamplesforMixingSmallN <- function(n, sample.df, subtype) {
   # all samples
   all.samples <- c(subtype.samples, other.samples)
   # array half
-  array.samples <- c(sample(subtype.samples, floor(n * .5)),
-                     sample(other.samples, ceiling(n * .5)))
+  array.samples <- c(sample(subtype.samples, floor(n * (1 - seq_proportion))),
+                     sample(other.samples, ceiling(n * (1 - seq_proportion))))
   # seq half
   seq.samples <- all.samples[!(all.samples %in% array.samples)]
 
@@ -801,7 +802,7 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
                                            mix.list$all)), with = FALSE]
   seq.full.dt  <- seq.dt[, c(1, which(colnames(seq.dt) %in%
                                         mix.list$all)), with = FALSE]
-
+  
   # array and seq data.tables to be used in the 50-50 experiment
   array.half.dt <- array.dt[, c(1, which(colnames(array.dt) %in%
                                            mix.list$array)), with = FALSE]

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -295,11 +295,11 @@ GetGeneSetStats <- function(silver.set,
   # calculate and return jaccard, rand index, and spearman
   jacc <- TP/(total - TN)
   rand <- (TP + TN)/total
-  spearman <- cor.test(combined_df$silver.adj.P.Val,
-                       combined_df$experimental.adj.P.Val,
-                       method = "spearman",
-                       exact = FALSE,
-                       continuity = TRUE)
+  spearman <- as.vector(cor.test(combined_df$silver.adj.P.Val,
+                                 combined_df$experimental.adj.P.Val,
+                                 method = "spearman",
+                                 exact = FALSE,
+                                 continuity = TRUE)$estimate)
   return(c(jacc, rand, spearman))
 }
 

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -463,7 +463,8 @@ PlotSilverStandardStats <- function(top.table.list, title,
            function(x) lapply(x,
                               function(y) GetGeneSetStats(top.table.list$`100`$un,
                                                           y, cutoff = cutoff)))
-  seq.stats.df <- reshape2::melt(seq.stats.list)
+  seq.stats.df <- reshape2::melt(seq.stats.list,
+                                 id.vars = c("jaccard", "rand", "spearman"))
   
   # how similiar are DEG results to the microarray silver standard?
   array.stats.list <-
@@ -471,7 +472,8 @@ PlotSilverStandardStats <- function(top.table.list, title,
            function(x) lapply(x,
                               function(y) GetGeneSetStats(top.table.list$`0`$log,
                                                           y, cutoff = cutoff)))
-  array.stats.df <- reshape2::melt(array.stats.list)
+  array.stats.df <- reshape2::melt(array.stats.list,
+                                   id.vars = c("jaccard", "rand", "spearman"))
   
   # combine seq and array similarity results
   array.stats.df <- cbind(array.stats.df, rep("Microarray", nrow(array.stats.df)))
@@ -660,7 +662,8 @@ GetSmallNSilverStandardStats <- function(top.table.list, cutoff = 0.05){
                       cutoff = cutoff)
   }
   
-  stats.df <- reshape2::melt(stats.list)
+  stats.df <- reshape2::melt(stats.list,
+                             id.vars = c("jaccard", "rand", "spearman"))
   colnames(stats.df) <-c("jaccard", "rand", "spearman",
                          "platform", "normalization", "no.samples")
   


### PR DESCRIPTION
Closes #75 

In response to reviewer requests, we would like to add additional metrics to compare sets of DEGs. Changes in this PR give updates to both the regular size n sample comparisons and the small n comparisons (at 50%/50% array/RNA-seq only). A follow up PR incorporates these commits and adds on the ability to work at (100-X%/X% array/RNA-seq).

Our current setup is to call the function `PlotSilverStandardJaccard()` in `utils/util/differential_expression_functions.R` which also calls `GetGeneSetJaccard()`. There is also a call to `GetSmallNSilverStandardJaccard()` for small n. The new setup has three new functions, `PlotSilverStandardStats()`, `GetGeneSetStats()`, and `GetSmallNSilverStandardStats()`. The new functions return stats and plots for Jaccard, Rand index, and Spearman correlation.

`GetGeneSetJaccard()` differs from `GetGeneSetStats()` in how it calculates Jaccard. `GetGeneSetJaccard()` looks at actual overlap of sets, while `GetGeneSetStats()` uses binary vectors to create a contingency table to quantify overlaps. For now, `*Jaccard()` functions are still kept around though they are not used in analysis scripts.

Future work (#77) will involve making the plotting code more sleek and making improvements for big-picture consistency across plots. Thank you :) 