### PR TITLE
Envest/74 expand small n

### DIFF
--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -119,7 +119,7 @@ doParallel::registerDoParallel(cl)
 
 # at each titration level (0-100% RNA-seq)
 stats.df.list[1:11] <- foreach(seq_prop = seq(0, 1, 0.1),
-                               .packages = c("magrittr")) %dopar% {
+                               .packages = c("tidyverse")) %dopar% {
   # we're going to repeat the small n experiment 10 times
   for (trial.iter in 1:10) {
     

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -180,6 +180,9 @@ stats.df <- reshape2::melt(stats.df.list,
                            id.vars = c("platform", "normalization", "no.samples"))
 names(stats.df) <- c("platform", "normalization", "no.samples", "metric", "value",
                      "iteration", "seq_prop")
+stats.df <- pivot_wider(stats.df,
+                        names_from = "metric",
+                        values_from = "value")
 
 write.table(stats.df,
             file = file.path(deg.dir,

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -168,7 +168,7 @@ names(stats.df.list)[1:11] <- as.character(seq(0, 100, 10))
 subtypes_combination <- stringr::str_c(two_subtypes, collapse = "v")
 subtypes_combination_nice <- stringr::str_c(two_subtypes, collapse = " vs. ")
 
-stats.df <- reshap2::melt(stats.df.list)
+stats.df <- reshape2::melt(stats.df.list)
 
 write.table(stats.df,
             file = file.path(deg.dir,

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -2,7 +2,6 @@
 # The purpose of this analysis is to examine how normalization methods
 # (quantile normalization or z-transformation) perform wrt differential
 # expression when there are a small number of samples on each platform
-# (50-50 split microarray and RNA-seq).
 #
 # USAGE: Rscript 3A-small_n_differential_expression.R --cancer_type --subtype_vs_subtype
 
@@ -118,13 +117,14 @@ cl <- parallel::makeCluster(detectCores() - 1)
 doParallel::registerDoParallel(cl)
 
 # at each titration level (0-100% RNA-seq)
-stats.df.list[1:11] <- foreach(seq_prop = seq(0, 1, 0.1),
-                               .packages = c("tidyverse")) %dopar% {
+stats.df.list[1:9] <- foreach(seq_prop = seq(0.1, .9, 0.1), .packages = c("tidyverse")) %dopar% {
+  
   # we're going to repeat the small n experiment 10 times
   for (trial.iter in 1:10) {
     
     # for each n (3...50), get the sample names that will be included in the
     # experiment and on each platform
+    stats.df.iter_list <- list()
     sample.list <-
       lapply(no.samples,  # for each n (3...50)
              function(x) GetSamplesforMixingSmallN(x, sample.df,
@@ -136,14 +136,19 @@ stats.df.list[1:11] <- foreach(seq_prop = seq(0, 1, 0.1),
     
     for (smpl.no.iter in seq_along(sample.list)) {  # for each n (3...50)
       # normalize data
-      norm.list <- SmallNNormWrapper(array.dt = array.dt,
-                                     seq.dt = seq.dt,
-                                     mix.list = sample.list[[smpl.no.iter]],
-                                     zto = FALSE)
-      # perform differential expression analysis
-      master.deg.list[[as.character(no.samples[smpl.no.iter])]] <-
-        SmallNDEGWrapper(norm.list = norm.list, sample.df = sample.df,
-                         subtype = data.table::last(two_subtypes))
+      n_array <- length(sample.list[[smpl.no.iter]]$array)
+      n_seq <- length(sample.list[[smpl.no.iter]]$seq)
+      
+      if (n_array >= 3 & n_seq >= 3) { # require at least three array and seq samples
+        norm.list <- SmallNNormWrapper(array.dt = array.dt,
+                                       seq.dt = seq.dt,
+                                       mix.list = sample.list[[smpl.no.iter]],
+                                       zto = FALSE)
+        # perform differential expression analysis
+        master.deg.list[[as.character(no.samples[smpl.no.iter])]] <-
+          SmallNDEGWrapper(norm.list = norm.list, sample.df = sample.df,
+                           subtype = data.table::last(two_subtypes)) 
+      }
     }
     
     top.table.list <-
@@ -153,17 +158,19 @@ stats.df.list[1:11] <- foreach(seq_prop = seq(0, 1, 0.1),
     
     # how do the 50/50 array/seq differentially expressed genes compared to
     # the platform-specific standards?
-    stats.df.list[[trial.iter]] <- GetSmallNSilverStandardStats(top.table.list,
-                                                                cutoff = 0.1)
-    
+    if (length(top.table.list) > 0) {
+      stats.df.iter_list[[trial.iter]] <- GetSmallNSilverStandardStats(top.table.list,
+                                                                       cutoff = 0.1)  
+    }
   }
+  stats.df.iter_list # return stats.df.iter_list to stats.df.list
 }
 
 # stop parallel backend
 parallel::stopCluster(cl)
 
 # renames list levels
-names(stats.df.list)[1:11] <- as.character(seq(0, 100, 10))
+names(stats.df.list)[1:9] <- as.character(seq(10, 90, 10))
 
 # combine jaccard similarity data.frames into one data.frame
 subtypes_combination <- stringr::str_c(two_subtypes, collapse = "v")
@@ -180,11 +187,13 @@ write.table(stats.df,
             sep = "\t", quote = FALSE, row.names = FALSE)
 
 # line plot is saved as a PDF
-for (percent_rna_seq %in% as.character(seq(0, 100, 10))) {
+for (percent_rna_seq in as.integer(names(stats.df.list))) {
   stats.df.pct <- stats.df %>%
-    filter(seq_prop = percent_rna_seq)
+    filter(seq_prop == percent_rna_seq)
   
-  ggplot(stats.df.pct, aes(x = no.samples, y = jaccard, color = platform)) +
+  ggplot(stats.df.pct, aes(x = no.samples,
+                           y = jaccard,
+                           color = platform)) +
     facet_wrap(~ normalization, ncol = 1) +
     stat_summary(fun = median, geom = "line", aes(group = platform),
                  position = position_dodge(0.2)) +
@@ -197,7 +206,8 @@ for (percent_rna_seq %in% as.character(seq(0, 100, 10))) {
     scale_colour_manual(values = cbPalette[c(2, 3)]) +
     theme(text = element_text(size = 18))
   ggsave(filename = here::here("plots",
-                               paste0(file_identifier, "_small_n_", subtypes_combination, "_", percent_rna_seq, "pct_rna_seq_jaccard_lineplots.pdf")),
+                               str_c(file_identifier, "small_n", subtypes_combination,
+                                     percent_rna_seq, "pct_rna_seq_jaccard_lineplots.pdf", sep = "_")),
          plot = last_plot(), width = 5, height = 7)
   
   ggplot(stats.df.pct, aes(x = no.samples, y = rand, color = platform)) +
@@ -213,7 +223,8 @@ for (percent_rna_seq %in% as.character(seq(0, 100, 10))) {
     scale_colour_manual(values = cbPalette[c(2, 3)]) +
     theme(text = element_text(size = 18))
   ggsave(filename = here::here("plots",
-                               paste0(file_identifier, "_small_n_", subtypes_combination, "_", percent_rna_seq, "pct_rna_seq_rand_lineplots.pdf")),
+                               str_c(file_identifier, "small_n", subtypes_combination,
+                                     percent_rna_seq, "pct_rna_seq_rand_lineplots.pdf", sep = "_")),
          plot = last_plot(), width = 5, height = 7)
   
   ggplot(stats.df.pct, aes(x = no.samples, y = spearman, color = platform)) +
@@ -229,6 +240,7 @@ for (percent_rna_seq %in% as.character(seq(0, 100, 10))) {
     scale_colour_manual(values = cbPalette[c(2, 3)]) +
     theme(text = element_text(size = 18))
   ggsave(filename = here::here("plots",
-                               paste0(file_identifier, "_small_n_", subtypes_combination, "_", percent_rna_seq, "pct_rna_seq_spearman_lineplots.pdf")),
+                               str_c(file_identifier, "small_n", subtypes_combination,
+                                     percent_rna_seq, "pct_rna_seq_spearman_lineplots.pdf", sep = "_")),
          plot = last_plot(), width = 5, height = 7)
 }

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -127,7 +127,7 @@ stats.df.list[1:11] <- foreach(seq_prop = seq(0, 1, 0.1)) %dopar% {
     sample.list <-
       lapply(no.samples,  # for each n (3...50)
              function(x) GetSamplesforMixingSmallN(x, sample.df,
-                                                   subtype = last(two_subtypes),
+                                                   subtype = data.table::last(two_subtypes),
                                                    seq_proportion = seq_prop))
     
     # initialize list to hold differential expression results (eBayes output)

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -118,7 +118,8 @@ cl <- parallel::makeCluster(detectCores() - 1)
 doParallel::registerDoParallel(cl)
 
 # at each titration level (0-100% RNA-seq)
-stats.df.list[1:11] <- foreach(seq_prop = seq(0, 1, 0.1)) %dopar% {
+stats.df.list[1:11] <- foreach(seq_prop = seq(0, 1, 0.1),
+                               .packages = c("magrittr")) %dopar% {
   # we're going to repeat the small n experiment 10 times
   for (trial.iter in 1:10) {
     

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -142,7 +142,7 @@ stats.df.list[1:11] <- foreach(seq_prop = seq(0, 1, 0.1)) %dopar% {
       # perform differential expression analysis
       master.deg.list[[as.character(no.samples[smpl.no.iter])]] <-
         SmallNDEGWrapper(norm.list = norm.list, sample.df = sample.df,
-                         subtype = last(two_subtypes))
+                         subtype = data.table::last(two_subtypes))
     }
     
     top.table.list <-

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -156,7 +156,7 @@ stats.df.list[1:9] <- foreach(seq_prop = seq(0.1, .9, 0.1), .packages = c("tidyv
              function(x)  # for each normalization method
                lapply(x, function(y) GetAllGenesTopTable(y)))  # extract DEGs
     
-    # how do the 50/50 array/seq differentially expressed genes compared to
+    # how do the (100-X)%/X% array/seq differentially expressed genes compared to
     # the platform-specific standards?
     if (length(top.table.list) > 0) {
       stats.df.iter_list[[trial.iter]] <- GetSmallNSilverStandardStats(top.table.list,

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -723,7 +723,7 @@ SmallNDEGWrapper <- function(norm.list, sample.df, subtype) {
 
 }
 
-GetSamplesforMixingSmallN <- function(n, sample.df, subtype) {
+GetSamplesforMixingSmallN <- function(n, sample.df, subtype, seq_proportion) {
   # This function is designed to identify sample names to be used in the "small
   # n" differential expression experiment
   #
@@ -731,6 +731,7 @@ GetSamplesforMixingSmallN <- function(n, sample.df, subtype) {
   #   n: number of samples (for each subtype - no. of replicates)
   #   sample.df: a data.frame mapping sample names to subtype labels
   #   subtype: which subtype should be compared to all others
+  #   seq_proportion: percentage of RNA-seq samples to include in mix
   #
   # Returns:
   #   A list comprised of the following:
@@ -755,8 +756,8 @@ GetSamplesforMixingSmallN <- function(n, sample.df, subtype) {
   # all samples
   all.samples <- c(subtype.samples, other.samples)
   # array half
-  array.samples <- c(sample(subtype.samples, floor(n * .5)),
-                     sample(other.samples, ceiling(n * .5)))
+  array.samples <- c(sample(subtype.samples, floor(n * (1 - seq_proportion))),
+                     sample(other.samples, ceiling(n * (1 - seq_proportion))))
   # seq half
   seq.samples <- all.samples[!(all.samples %in% array.samples)]
 
@@ -801,7 +802,7 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
                                            mix.list$all)), with = FALSE]
   seq.full.dt  <- seq.dt[, c(1, which(colnames(seq.dt) %in%
                                         mix.list$all)), with = FALSE]
-
+  
   # array and seq data.tables to be used in the 50-50 experiment
   array.half.dt <- array.dt[, c(1, which(colnames(array.dt) %in%
                                            mix.list$array)), with = FALSE]

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -819,9 +819,14 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   # remove any rows (genes) that all have same values, will cause issues with
   # z-score
   GetAllSameRowIndex <- function(x){
-    vals <- x[, 2:ncol(x), with = FALSE]
-    indx <- which(apply(vals, 1, check_all_same))
-    return(indx)
+    if (ncol(x) > 1) { # check that there is at least one data column
+      # there will be no data column when no seq or no array samples are included
+      vals <- x[, 2:ncol(x), with = FALSE]
+      indx <- which(apply(vals, 1, check_all_same))
+      return(indx)
+    } else {
+      return(integer(0))
+    }
   }
 
   all.same.indx <- unique(c(GetAllSameRowIndex(seq.full.dt),

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -295,7 +295,11 @@ GetGeneSetStats <- function(silver.set,
   total <- sum(contingency_table)
   
   # calculate and return jaccard, rand index, and spearman
-  jacc <- TP/(total - TN)
+  if (total == TN) { # denominator of 0 leads to NaN
+    jacc <- 0
+  } else {
+    jacc <- TP/(total - TN)  
+  }
   rand <- (TP + TN)/total
   spearman <- as.vector(cor.test(combined_df$silver.adj.P.Val,
                                  combined_df$experimental.adj.P.Val,

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -847,12 +847,26 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   norm.list[["log"]] <- LOGArrayOnly(array.full.dt, zto)
   norm.list[["un"]] <- seq.full.dt
   # 50-50 experiments
-  norm.list[["qn"]] <- QNProcessing(array.dt = array.half.dt,
-                                    seq.dt = seq.half.dt,
+  if (ncol(seq.half.df) == 1) { # no seq samples added, array only
+    norm.list[["qn"]] <- QNSingleDT(dt = array.half.df,
                                     zero.to.one = zto)
-  norm.list[["z"]] <- ZScoreProcessing(array.dt = array.half.dt,
-                                       seq.dt = seq.half.dt,
+    norm.list[["z"]] <- ZScoreSingleDT(dt = array.half.df,
                                        zero.to.one = zto)
+  } else if (ncol(array.half.df) == 1) { # no array samnples added, seq only
+    norm.list[["qn"]] <- QNSingleDT(dt = seq.half.df,
+                                    zero.to.one = zto)
+    norm.list[["z"]] <- ZScoreSingleDT(dt = seq.half.df,
+                                       zero.to.one = zto)
+    
+  } else {
+    norm.list[["qn"]] <- QNProcessing(array.dt = array.half.dt,
+                                      seq.dt = seq.half.dt,
+                                      zero.to.one = zto)
+    norm.list[["z"]] <- ZScoreProcessing(array.dt = array.half.dt,
+                                         seq.dt = seq.half.dt,
+                                         zero.to.one = zto)
+  }
+  
   return(norm.list)
-
+  
 }

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -550,7 +550,7 @@ PlotSilverStandardStats <- function(top.table.list, title,
 GetSmallNSilverStandardJaccard <- function(top.table.list, cutoff = 0.05){
   # This function takes a list of limma::topTable output, derives "silver
   # standards" from 100% array and 100% seq data, and finds the Jaccard
-  # similarity between the standards and 50-50 experiment differential
+  # similarity between the standards and titrated experiment differential
   # expression results (quantile norm and z-score)
   #
   # Args:
@@ -711,7 +711,7 @@ SmallNDEGWrapper <- function(norm.list, sample.df, subtype) {
   }
 
   full.design.mat <- GetDesignMat(norm.list$log, sample.df, subtype)
-  half.design.mat <- GetDesignMat(norm.list$qn, sample.df, subtype)
+  part.design.mat <- GetDesignMat(norm.list$qn, sample.df, subtype)
 
   # initialize list to hold fits
   fit.list <- list()
@@ -726,9 +726,9 @@ SmallNDEGWrapper <- function(norm.list, sample.df, subtype) {
   voom.counts <- limma::voom(counts = exprs)
   fit.list[["un"]] <- GetFiteBayes(voom.counts, full.design.mat)
 
-  # 50-50 split data experiment - quantile normalization and z-transformation
-  fit.list[["qn"]] <- GetFiteBayes(norm.list$qn, half.design.mat)
-  fit.list[["z"]] <- GetFiteBayes(norm.list$z, half.design.mat)
+  # (100-X)%/X% split data experiment - quantile normalization and z-transformation
+  fit.list[["qn"]] <- GetFiteBayes(norm.list$qn, part.design.mat)
+  fit.list[["z"]] <- GetFiteBayes(norm.list$z, part.design.mat)
 
   return(fit.list)
 
@@ -748,8 +748,8 @@ GetSamplesforMixingSmallN <- function(n, sample.df, subtype, seq_proportion) {
   #   A list comprised of the following:
   #     all: names of all samples to be used for the experiment (100% of
   #          a single platform)
-  #     array: names of samples to be used for array half of experiment
-  #     seq: names of samples to be used for sequencing half of experiment
+  #     array: names of samples to be used for array part of experiment
+  #     seq: names of samples to be used for sequencing part of experiment
   #
 
   # get samples from the subtype of interest
@@ -766,10 +766,10 @@ GetSamplesforMixingSmallN <- function(n, sample.df, subtype, seq_proportion) {
 
   # all samples
   all.samples <- c(subtype.samples, other.samples)
-  # array half
+  # array part
   array.samples <- c(sample(subtype.samples, floor(n * (1 - seq_proportion))),
                      sample(other.samples, ceiling(n * (1 - seq_proportion))))
-  # seq half
+  # seq part
   seq.samples <- all.samples[!(all.samples %in% array.samples)]
 
   return(list("all" = all.samples, "array" = array.samples,
@@ -782,7 +782,7 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   # differential expression experiment -- it will return a list of normalized
   # data that includes two controls (100% log-transformed array data and
   # and 100% untransformed RNA-seq count data (RSEM)) and two experimental
-  # datasets (50-50 array and seq data either quantile normalized or
+  # datasets (titrated array and seq data either quantile normalized or
   # z-transformed)
   #
   # Args:
@@ -797,8 +797,8 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   # Returns:
   #   norm.list: a normalized list of data with log (100% array data),
   #              un (100% untransformed RNA-seq data), qn (quantile normalized
-  #              data that is 50-50 array/seq data [the array data is used as
-  #              the reference]), and z (z-transformed data that is 50-50
+  #              data that is titrated array/seq data [the array data is used as
+  #              the reference]), and z (z-transformed data that is titrated
   #              array/seq data [z-scores within platform + concatenation])
   #
 
@@ -814,10 +814,10 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   seq.full.dt  <- seq.dt[, c(1, which(colnames(seq.dt) %in%
                                         mix.list$all)), with = FALSE]
   
-  # array and seq data.tables to be used in the 50-50 experiment
-  array.half.dt <- array.dt[, c(1, which(colnames(array.dt) %in%
+  # array and seq data.tables to be used in the titrated experiment
+  array.part.dt <- array.dt[, c(1, which(colnames(array.dt) %in%
                                            mix.list$array)), with = FALSE]
-  seq.half.dt <- seq.dt[, c(1, which(colnames(seq.dt) %in%
+  seq.part.dt <- seq.dt[, c(1, which(colnames(seq.dt) %in%
                                        mix.list$seq)), with = FALSE]
 
   # remove any rows (genes) that all have same values, will cause issues with
@@ -834,15 +834,15 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   }
 
   all.same.indx <- unique(c(GetAllSameRowIndex(seq.full.dt),
-                            GetAllSameRowIndex(seq.half.dt)))
+                            GetAllSameRowIndex(seq.part.dt)))
   # if no rows are all same (in previous GetAllSameRowIndex), all.same.indx is integer(0)
   # subsetting data frames by -integer(0) results in no rows
   # so check that integer vector has length > 0 before subsetting
   if (length(all.same.indx) > 0) {
     array.full.dt <- array.full.dt[-all.same.indx, ]
     seq.full.dt <- seq.full.dt[-all.same.indx, ]
-    array.half.dt <- array.half.dt[-all.same.indx, ]
-    seq.half.dt <- seq.half.dt[-all.same.indx, ]
+    array.part.dt <- array.part.dt[-all.same.indx, ]
+    seq.part.dt <- seq.part.dt[-all.same.indx, ]
   }
 
   # initialize list to hold normalized data
@@ -850,24 +850,24 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   # control conditions 100% log-transformed array data & 100% RSEM seq data
   norm.list[["log"]] <- LOGArrayOnly(array.full.dt, zto)
   norm.list[["un"]] <- seq.full.dt
-  # 50-50 experiments
-  if (ncol(seq.half.dt) == 1) { # no seq samples added, array only
-    norm.list[["qn"]] <- QNSingleDT(dt = array.half.dt,
+  # titrated experiments
+  if (ncol(seq.part.dt) == 1) { # no seq samples added, array only
+    norm.list[["qn"]] <- QNSingleDT(dt = array.part.dt,
                                     zero.to.one = zto)
-    norm.list[["z"]] <- ZScoreSingleDT(dt = array.half.dt,
+    norm.list[["z"]] <- ZScoreSingleDT(dt = array.part.dt,
                                        zero.to.one = zto)
-  } else if (ncol(array.half.dt) == 1) { # no array samnples added, seq only
-    norm.list[["qn"]] <- QNSingleDT(dt = seq.half.dt,
+  } else if (ncol(array.part.dt) == 1) { # no array samnples added, seq only
+    norm.list[["qn"]] <- QNSingleDT(dt = seq.part.dt,
                                     zero.to.one = zto)
-    norm.list[["z"]] <- ZScoreSingleDT(dt = seq.half.dt,
+    norm.list[["z"]] <- ZScoreSingleDT(dt = seq.part.dt,
                                        zero.to.one = zto)
     
   } else {
-    norm.list[["qn"]] <- QNProcessing(array.dt = array.half.dt,
-                                      seq.dt = seq.half.dt,
+    norm.list[["qn"]] <- QNProcessing(array.dt = array.part.dt,
+                                      seq.dt = seq.part.dt,
                                       zero.to.one = zto)
-    norm.list[["z"]] <- ZScoreProcessing(array.dt = array.half.dt,
-                                         seq.dt = seq.half.dt,
+    norm.list[["z"]] <- ZScoreProcessing(array.dt = array.part.dt,
+                                         seq.dt = seq.part.dt,
                                          zero.to.one = zto)
   }
   

--- a/util/differential_expression_functions.R
+++ b/util/differential_expression_functions.R
@@ -847,15 +847,15 @@ SmallNNormWrapper <- function(array.dt, seq.dt, mix.list, zto = FALSE) {
   norm.list[["log"]] <- LOGArrayOnly(array.full.dt, zto)
   norm.list[["un"]] <- seq.full.dt
   # 50-50 experiments
-  if (ncol(seq.half.df) == 1) { # no seq samples added, array only
-    norm.list[["qn"]] <- QNSingleDT(dt = array.half.df,
+  if (ncol(seq.half.dt) == 1) { # no seq samples added, array only
+    norm.list[["qn"]] <- QNSingleDT(dt = array.half.dt,
                                     zero.to.one = zto)
-    norm.list[["z"]] <- ZScoreSingleDT(dt = array.half.df,
+    norm.list[["z"]] <- ZScoreSingleDT(dt = array.half.dt,
                                        zero.to.one = zto)
-  } else if (ncol(array.half.df) == 1) { # no array samnples added, seq only
-    norm.list[["qn"]] <- QNSingleDT(dt = seq.half.df,
+  } else if (ncol(array.half.dt) == 1) { # no array samnples added, seq only
+    norm.list[["qn"]] <- QNSingleDT(dt = seq.half.dt,
                                     zero.to.one = zto)
-    norm.list[["z"]] <- ZScoreSingleDT(dt = seq.half.df,
+    norm.list[["z"]] <- ZScoreSingleDT(dt = seq.half.dt,
                                        zero.to.one = zto)
     
   } else {


### PR DESCRIPTION
Closes #74 
Depends on #78 (this is intended to be a nested PR)

Our current setup is to run the small n comparison using small data sets composed of 50% array data and 50% RNA-seq data. A reviewer thought and we agreed it would be nice to generalize those percentages to 100-X% array and X% RNA-seq. We have done that by allowing the percentage RNA-seq specified in `GetSamplesForMixingSmallN()` (`util/differential_expression_functions.R`) to vary and parallelizing over the percentage seq.

I set limits of how low/high the percentage seq can range (10% to 90%), and I included checks for the number of samples coming from array and seq because we may not get enough samples for some combinations of percentage seq and sample size. I also edited references to half/half or 50%/50% in favor of more inclusive language.

An important TODO which I have left for future work (#77) is ensuring the x-axis values are a.) in order and b.) consistent across all plots going into the same figure 😛 Thanks!