### PR TITLE
Envest/73 plier 02 extract plier pathways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ data
 normalized_data
 models
 results/reconstructed_data
+.Rproj.user
+RNAseq_titration_results.Rproj

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -1,6 +1,6 @@
-# S. Foltz Nov 2021
+# Steven Foltz Nov 2021
 # The purpose of this analysis is to use PLIER to identify expression pathways
-# in our data, using pure microarray and RNA-seq data as comparison standards
+# in our data, and quantify the rate of return for significant PLIER pathways
 # for data coming from different normalization methods and titration levels.
 #
 # USAGE: Rscript 7-extract_plier_pathways.R --cancer_type --seed
@@ -8,10 +8,12 @@
 option_list <- list(
   optparse::make_option("--cancer_type",
                         default = NA_character_,
-                        help = "Cancer type"),
+                        help = "Cancer type"
+  ),
   optparse::make_option("--seed",
                         default = 8934,
-                        help = "Random seed")
+                        help = "Random seed"
+  )
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list = option_list))
@@ -30,27 +32,24 @@ file_identifier <- str_c(cancer_type, "subtype", sep = "_") # assuming subtype
 # set seed
 initial.seed <- opt$seed
 set.seed(initial.seed)
-message(paste("\nInitial seed set to:", initial.seed))
+message(paste("\nPLIER initial seed set to:", initial.seed))
 
 # define directories
 data.dir <- here::here("data")
 norm.data.dir <- here::here("normalized_data")
 res.dir <- here::here("results")
+plots.dir <- here::here("plots")
 
 # define input files
-# finds first example of a subtypes file from cancer_type, does not rely on seed
-#norm.test.files <- file.path(norm.data.dir,
-#                            list.files(norm.data.dir,
-#                                       pattern = paste0(file_identifier,
-#                                                        "_array_seq_test_data_normalized_list_")))
-norm.train.files <- file.path(norm.data.dir,
-                             list.files(norm.data.dir,
-                                        pattern = paste0(file_identifier,
-                                                         "_array_seq_train_titrate_normalized_list_")))
-sample.files <- file.path(res.dir,
-                         list.files(res.dir,
-                                    pattern = paste0(file_identifier,
-                                                     "_matchedSamples_training_testing_split_labels_")))
+norm.train.files <- file.path(
+  norm.data.dir,
+  list.files(norm.data.dir,
+             pattern = paste0(
+               file_identifier,
+               "_array_seq_train_titrate_normalized_list_"
+             )
+  )
+)
 
 #### set up PLIER data ---------------------------------------------------------
 
@@ -59,81 +58,262 @@ data(canonicalPathways)
 data(oncogenicPathways)
 data(svmMarkers)
 
-all.paths <- PLIER::combinePaths(bloodCellMarkersIRISDMAP,
-                                 canonicalPathways,
-                                 oncogenicPathways,
-                                 svmMarkers)
+all.paths <- PLIER::combinePaths(
+  bloodCellMarkersIRISDMAP,
+  canonicalPathways,
+  oncogenicPathways,
+  svmMarkers
+)
+
+PLIER_pathways <- colnames(all.paths)
 
 #### Function for converting column to row names -------------------------------
 
-convert_row_names <- function(expr, cancer_type){
+convert_row_names <- function(expr, cancer_type) {
+  # If the cancer type is GBM, convert ENSG to gene symbols
+  # then convert the gene column to rownames
+  #
+  # Inputs: gene expression matrix with genes in first column, and cancer type
+  # Returns: modified gene expression matrix with gene names as row names
+  
   if (cancer_type == "GBM") {
     expr <- expr %>%
       mutate(gene = ensembldb::select(EnsDb.Hsapiens.v86::EnsDb.Hsapiens.v86,
                                       keys = as.character(gene),
                                       keytype = "GENEID",
-                                      columns = "SYMBOL")$SYMBOL)
+                                      columns = "SYMBOL"
+      )$SYMBOL)
   }
+  
   column_to_rownames(expr,
-                     var = "gene")
+                     var = "gene"
+  )
+}
+
+#### Failure of PLIER to converge may manifest in different error messages...
+
+check_plier_failure_to_converge <- function(plier_result) {
+
+  # if the plier result contained an error message
+  if ("message" %in% names(plier_result)) {
+    # and if that error massage refers to convergence failure directly or indirectly
+    if (str_detect(plier_result$message, "system is computationally singular") | 
+        str_detect(plier_result$message, "subscript out of bounds")) {
+      NA # return NA
+    } else { # PLIER failed for another reason and we need to know about that
+      stop("PLIER run failed for reason other than system is computationally singular")
+    }
+  } else {
+    plier_result # return the plier result as is
+  }
+}
+
+#### Functions to get jaccard values from a list of PLIER results ---------------
+
+return_plier_jaccard_silver <- function(test_PLIER, array_silver, seq_silver) {
+  # Given a set of PLIER results (which is a list), compare significant pathways
+  # to two silver sets of pathways defined by array and RNA-seq data only
+  # Jaccard similarity is defined as O(intersect)/O(union). If the input is not
+  # a properly completed PLIER result, then return all NAs.
+  # 
+  # Inputs: PLIER result, pathway set 1, pathway set 2
+  # Returns: data frame with two rows (array, seq) with stats for each overlap
+  
+  if ("summary" %in% names(test_PLIER)) {
+    
+    test_pathways <- test_PLIER[["summary"]] %>%
+      filter(FDR < 0.05) %>%
+      pull(pathway) %>%
+      unique()
+    
+    array_jaccard <- length(intersect(array_silver, test_pathways)) / length(union(array_silver, test_pathways))
+    seq_jaccard <- length(intersect(seq_silver, test_pathways)) / length(union(seq_silver, test_pathways))
+    
+    data.frame(
+      silver = c("array", "seq"),
+      n_silver = c(
+        length(array_silver),
+        length(seq_silver)
+      ),
+      n_test = length(test_pathways),
+      n_intersect = c(
+        length(intersect(array_silver, test_pathways)),
+        length(intersect(seq_silver, test_pathways))
+      ),
+      n_union = c(
+        length(union(array_silver, test_pathways)),
+        length(union(seq_silver, test_pathways))
+      ),
+      n_common_genes = nrow(test_PLIER[["Z"]]),
+      k = ncol(test_PLIER[["Z"]]),
+      jaccard = c(
+        array_jaccard,
+        seq_jaccard
+      )
+    )
+  } else {
+    
+    data.frame(
+      silver = NA,
+      n_silver = NA,
+      n_test = NA,
+      n_intersect = NA,
+      n_union = NA,
+      n_common_genes = NA,
+      k = NA,
+      jaccard = NA
+    )  
+    
+  }
+}
+
+return_plier_jaccard_global <- function(test_PLIER, global_pathways) {
+  # Given a set of PLIER results (which is a list), compare significant pathways
+  # to a global set of pathways defined by the existing PLIER pathways
+  # Jaccard similarity is defined as O(intersect)/O(union). If the input is not
+  # a properly completed PLIER result, then return all NAs.
+  #
+  # Inputs: PLIER result, global pathways
+  # Returns: data frame with one row with stats for each overlap
+  
+  if ("summary" %in% names(test_PLIER)) {
+    
+    test_pathways <- test_PLIER[["summary"]] %>%
+      filter(FDR < 0.05) %>%
+      pull(pathway) %>%
+      unique()
+    
+    global_jaccard <- length(intersect(global_pathways, test_pathways)) / length(global_pathways)
+    
+    data.frame(
+      n_global = length(global_pathways),
+      n_test = length(test_pathways),
+      n_intersect = length(intersect(global_pathways, test_pathways)),
+      n_common_genes = nrow(test_PLIER[["Z"]]),
+      k = ncol(test_PLIER[["Z"]]),
+      jaccard = global_jaccard
+    ) 
+    
+  } else {
+    
+    data.frame(
+      n_global = NA,
+      n_test = NA,
+      n_intersect = NA,
+      n_common_genes = NA,
+      k = NA,
+      jaccard = NA
+    )
+    
+  }
 }
 
 #### loop over data for each seed and get PLIER results ------------------------
 
-for(seed_index in 1:length(norm.train.files)) {
-  
-  message(str_c("PLIER with data seed ", seed_index,
-                "out of ", length(norm.train.files), "..."))
+jaccard_list <- list()
+
+for (seed_index in 1:length(norm.train.files)) {
+  message(str_c("PLIER with data seed", seed_index,
+                "out of", length(norm.train.files), "...",
+                sep = " "
+  ))
   
   #### read in data ------------------------------------------------------------
   
-  #norm.test.list <- read_rds(norm.test.files[seed_index])
   norm.train.list <- read_rds(norm.train.files[seed_index])
-  sample.df <- read.delim(sample.files[seed_index])
   
   # convert gene names column to row names
   # if GBM, also convert from GENEID to SYMBOL
-  norm.train.list <- purrr::modify_depth(norm.train.list, 2,
-                                         function(x) convert_row_names(expr = x,
-                                                                       cancer_type = cancer_type))
-  
-  #### get common gene set -----------------------------------------------------
-  
-  common.genes <- PLIER::commonRows(all.paths,
-                                    norm.train.list[["0"]][["z"]])
-  
+  norm.train.list <- purrr::modify_depth(
+    norm.train.list, 2,
+    function(x) {
+      convert_row_names(
+        expr = x,
+        cancer_type = cancer_type
+      )
+    }
+  )
+
   #### main --------------------------------------------------------------------
   
+  # parallel backend
+  cl <- parallel::makeCluster(floor(detectCores()/2))
+  doParallel::registerDoParallel(cl)
+
   # create an output list
   plier_results_list <- list()
   
-  # parallel backend
-  cl <- parallel::makeCluster(detectCores() - 1)
-  doParallel::registerDoParallel(cl)
+  # at different titration levels (0-100% RNA-seq) and normalization methods
+  # generate the PLIER results for array alone, seq alone, and array + seq combo
   
-  # at each titration level (0-100% RNA-seq)
-  perc_seq <- as.character(seq(0, 100, 10))
-  norm_methods <- c("log", "npn", "qn", "tdm", "z")
-  plier_results_list <- foreach(ps = perc_seq, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
-    foreach(nm = norm_methods, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
-      
+  perc_seq <- as.character(seq(0, 100, 50))
+  norm_methods_if_0_100 <- c("log")
+  norm_methods_else <- c("log", "npn", "qn", "qn-z", "tdm", "z",
+                         "array_only", "seq_only")
+
+  plier_results_list <- foreach(
+    ps = perc_seq,
+    .packages = c("PLIER", "doParallel")
+  ) %do% {
+    message(str_c("  PLIER at ", ps, "% RNA-seq"))
+
+    if (ps %in% c("0", "100")) { # no need to add array_only or seq_only
+
+      norm_methods <- norm_methods_if_0_100
+
+    } else {
+
+      norm_methods <- norm_methods_else
+
+      # get array and seq sample columns     
+      array_only_columns_tf <- names(norm.train.list[["0"]][["log"]]) %in%
+        names(norm.train.list[[ps]][["raw.array"]])
+
+      seq_only_columns_tf <- !array_only_columns_tf
+
+      # add array only and seq only data to each % RNA-seq
+      norm.train.list[[ps]][["array_only"]] <- norm.train.list[["0"]][["log"]][,array_only_columns_tf]
+      norm.train.list[[ps]][["seq_only"]] <- norm.train.list[["100"]][["log"]][,seq_only_columns_tf]
+
+    }
+
+    foreach(
+      nm = norm_methods,
+      .packages = c("PLIER", "doParallel"),
+      .errorhandling = "pass" # let pass on inside loop
+    ) %dopar% {
+
       if (nm %in% names(norm.train.list[[ps]])) {
-        if(any(apply(norm.train.list[[ps]][[nm]], 1, check_all_same))) {
-          c("Some rows all same value...") # TODO This shouldn't be happening?
-        } else {
-          # minimum k for PLIER = 2*num.pc
-          # TODO alternatively, should we just set one k for all data sets?
-          set.k <- 2*PLIER::num.pc(norm.train.list[[ps]][[nm]][common.genes, ])
-          
-          # PLIER main function
-          PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
-                       all.paths[common.genes, ],
-                       k = set.k,
-                       trace = FALSE,
-                       scale = TRUE)
+
+        # remove any rows with all the same value
+        all.same.indx <- which(apply(
+          norm.train.list[[ps]][[nm]], 1,
+          check_all_same
+        ))
+
+        if (length(all.same.indx) > 0) {
+          norm.train.list[[ps]][[nm]] <- norm.train.list[[ps]][[nm]][-all.same.indx, ]
         }
+
+        # get common genes
+        common.genes <- PLIER::commonRows(
+          all.paths,
+          norm.train.list[[ps]][[nm]]
+        )
+
+        # minimum k for PLIER = 2*num.pc
+        set.k <- 2 * PLIER::num.pc(PLIER::rowNorm(norm.train.list[[ps]][[nm]][common.genes, ]))
+
+        # PLIER main function
+        PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
+                     all.paths[common.genes, ],
+                     k = set.k,
+                     scale = TRUE # PLIER z-scores input values by row
+        )
+
       } else {
-        c("No data for this combination...") # TODO For downstream data handling, considering making NULL
+
+        NA # NA for no data at this ps nm combination (0% and 100% TDM)
       }
     }
   }
@@ -144,11 +324,79 @@ for(seed_index in 1:length(norm.train.files)) {
   # renames list levels
   names(plier_results_list) <- perc_seq
   for (i in perc_seq) {
-    names(plier_results_list[[i]]) <- norm_methods
+    if (i %in% c("0", "100")) {
+      names(plier_results_list[[i]]) <- norm_methods_if_0_100
+    } else {
+      names(plier_results_list[[i]]) <- norm_methods_else
+    }
   }
   
-  # TODO NOW DO COMPARISON METRIC  
-
+  # Check for failure to converge, and set to NA
+  plier_results_list <- purrr::modify_depth(plier_results_list, 2,
+                                            check_plier_failure_to_converge
+  )
+  
+  # Return pathway comparison for appropriate level of PLIER results list
+  jaccard_list[[seed_index]] <- purrr::modify_depth(
+    plier_results_list, 2,
+    function(x) return_plier_jaccard_global(x, PLIER_pathways)
+  )
+  
 }
 
-# TODO PLOT THAT
+if (length(jaccard_list) > 0) {
+  
+  # melt jaccard list elements into one data frame
+  jaccard_df <- reshape2::melt(
+    data = jaccard_list,
+    id.vars = c(
+      "n_global", "n_test", "n_intersect",
+      "n_common_genes", "k"
+    ),
+    value.name = "jaccard"
+  ) %>%
+    rename(
+      "nmeth" = "L3", # normalization method
+      "pseq" = "L2", # percentage RNA-seq
+      "seed_index" = "L1"
+    )
+  
+  readr::write_tsv(
+    x = jaccard_df,
+    path = file.path(
+      res.dir,
+      str_c(file_identifier, "_PLIER_jaccard.tsv")
+    )
+  )
+  
+  # Plot results
+  
+  plot_filename = file.path(
+    plots.dir,
+    str_c(file_identifier, "_PLIER_jaccard.pdf")
+  )
+  
+  jaccard_df %>%
+    mutate(pseq = as.factor(pseq),
+           nmeth = str_to_upper(nmeth)) %>%
+    ggplot(aes(x = pseq,
+               y = jaccard)) +
+    geom_violin() +
+    stat_summary(fun = median, geom = "line", aes(group = "pseq"),
+                 position = position_dodge(0.6)) +
+    stat_summary(fun = median, geom = "point", aes(group = "pseq"),
+                 position = position_dodge(0.7), size = 1) +
+    expand_limits(y = 0) +
+    facet_wrap(~ nmeth,
+               nrow = 1) +
+    ggtitle(cancer_type) +
+    xlab("% RNA-seq samples") +
+    ylab("Proportion") +
+    theme_bw() +
+    theme(text = element_text(size = 18)) +
+    theme(axis.text.x = element_text(angle = 45, vjust = 0.5))
+  
+  ggsave(plot_filename,
+         plot = last_plot(),
+         height = 3.5, width = 15)
+}

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -75,8 +75,8 @@ for(seed_index in 1:2) {
   #### read in data ------------------------------------------------------------
   
   #norm.test.list <- read_rds(norm.test.files[seed_index])
-  norm.train.list <- read_rds(norm.train.filex[seed_index])
-  sample.df <- read.delim(sample.filex[seed_index])
+  norm.train.list <- read_rds(norm.train.files[seed_index])
+  sample.df <- read.delim(sample.files[seed_index])
   
   # convert gene names column to row names
   # convert GBM gene names to SYMBOL

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -1,0 +1,123 @@
+# S. Foltz Nov 2021
+# The purpose of this analysis is to use PLIER to identify expression pathways
+# in our data, using pure microarray and RNA-seq data as comparison standards
+# for data coming from different normalization methods and titration levels.
+#
+# USAGE: Rscript 7-extract_plier_pathways.R --cancer_type --seed
+
+option_list <- list(
+  optparse::make_option("--cancer_type",
+                        default = NA_character_,
+                        help = "Cancer type"),
+  optparse::make_option("--seed",
+                        default = 8934,
+                        help = "Random seed")
+)
+
+opt <- optparse::parse_args(optparse::OptionParser(option_list = option_list))
+source(here::here("util/option_functions.R"))
+check_options(opt)
+
+# load libraries
+suppressMessages(source(here::here("load_packages.R")))
+source(here::here("util", "color_blind_friendly_palette.R"))
+
+# set options
+cancer_type <- opt$cancer_type
+file_identifier <- str_c(cancer_type, "subtype", sep = "_") # assuming subtype
+
+# set seed
+initial.seed <- opt$seed
+set.seed(initial.seed)
+message(paste("\nInitial seed set to:", initial.seed))
+
+# define directories
+data.dir <- here::here("data")
+norm.data.dir <- here::here("normalized_data")
+res.dir <- here::here("results")
+
+# define input files
+# finds first example of a subtypes file from cancer_type, does not rely on seed
+#norm.test.object <- file.path(norm.data.dir,
+#                              list.files(norm.data.dir,
+#                                         pattern = paste0(file_identifier,
+#                                                          "_array_seq_test_data_normalized_list_"))[1])
+norm.train.object <- file.path(norm.data.dir,
+                               list.files(norm.data.dir,
+                                          pattern = paste0(file_identifier,
+                                                           "_array_seq_train_titrate_normalized_list_"))[1])
+sample.file <- file.path(res.dir,
+                         list.files(res.dir,
+                                    pattern = paste0(file_identifier,
+                                                     "_matchedSamples_training_testing_split_labels_"))[1])
+
+#### read in data --------------------------------------------------------------
+
+#norm.test.list <- read_rds(norm.test.object)
+norm.train.list <- read_rds(norm.train.object)
+sample.df <- read.delim(sample.file)
+
+#### set up PLIER data ---------------------------------------------------------
+
+data(bloodCellMarkersIRISDMAP)
+data(canonicalPathways)
+data(oncogenicPathways)
+data(svmMarkers)
+
+all.paths <- PLIER::combinePaths(bloodCellMarkersIRISDMAP,
+                                 canonicalPathways,
+                                 oncogenicPathways,
+                                 svmMarkers)
+
+common.genes <- PLIER::commonRows(all.paths,
+                                  norm.train.list#TODO UPDATE)
+
+#### main ----------------------------------------------------------------------
+
+# repeatable PLIER function
+run_plier <- function(expr_data, paths, genes){
+
+  # minimum k for PLIER = 2*num.pc
+  set.k <- 2*PLIER::num.pc(expr_data[genes, ])
+
+  # PLIER main function
+  PLIER::PLIER(expr_data[genes, ],
+               paths[genes, ],
+               k = set.k,
+               trace = TRUE,
+               scale = F)
+}
+
+# create an output list
+plier_results_list <- list()
+
+# PLIER at pure array
+plier_results_list["array"] <- run_plier(DATA,
+                                         all.paths,
+                                         common.genes)
+
+# PLIER at pure RNA-seq
+plier_results_list["seq"] <- run_plier(DATA,
+                                       all.paths,
+                                       common.genes)
+
+# Do this at 0-100% RNA-seq titration levels
+# across each normalization method
+# parallel backend
+cl <- parallel::makeCluster(detectCores() - 1)
+doParallel::registerDoParallel(cl)
+
+# at each titration level (0-100% RNA-seq)
+plier_results_list["titrated"][1:9] <- foreach(seq_prop = seq(0.1, .9, 0.1), .packages = c("tidyverse")) %dopar% {
+
+  run_plier(DATA,
+            all.paths,
+            common.genes)
+
+}
+
+# stop parallel backend
+parallel::stopCluster(cl)
+
+# renames list levels
+names(plier_results_list["titrated"])[1:9] <- as.character(seq(10, 90, 10))

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -64,7 +64,7 @@ convert_row_names <- function(expr, cancer_type){
   if (cancer_type == "GBM") {
     expr <- expr %>%
       mutate(gene = ensembldb::select(EnsDb.Hsapiens.v86::EnsDb.Hsapiens.v86,
-                                      keys= as.character(gene),
+                                      keys = as.character(gene),
                                       keytype = "GENEID",
                                       columns = "SYMBOL")$SYMBOL)
   }
@@ -93,6 +93,8 @@ common.genes <- PLIER::commonRows(all.paths,
 
 #### main ----------------------------------------------------------------------
 
+# TODO Loop over all seeds
+
 # create an output list
 plier_results_list <- list()
 
@@ -106,7 +108,7 @@ norm_methods <- c("log", "npn", "qn", "tdm", "z")
 plier_results_list <- foreach(ps = perc_seq, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
   foreach(nm = norm_methods, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
 
-    if (nm %in% names(norm.train.list[[ps]])){
+    if (nm %in% names(norm.train.list[[ps]])) {
       if(any(apply(norm.train.list[[ps]][[nm]], 1, check_all_same))) {
         c("Some rows all same value...")
       } else {
@@ -129,9 +131,16 @@ plier_results_list <- foreach(ps = perc_seq, .packages = c("PLIER", "doParallel"
 # stop parallel backend
 parallel::stopCluster(cl)
 
+# renames list levels
+names(plier_results_list) <- perc_seq
+for (i in perc_seq) {
+  names(plier_results_list[[i]]) <- norm_methods
+}
+
+# TODO REMOVE THIS
 write_rds(x = plier_results_list,
           path = "test.rds")
 
-# renames list levels
-#names(plier_results_list) <- perc_seq
-#lapply(plier_results_list, names(x) <- norm_methods)
+# TODO NOW DO COMPARISON METRIC
+
+# TODO PLOT THAT

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -137,10 +137,6 @@ for (i in perc_seq) {
   names(plier_results_list[[i]]) <- norm_methods
 }
 
-# TODO REMOVE THIS
-write_rds(x = plier_results_list,
-          path = "test.rds")
-
 # TODO NOW DO COMPARISON METRIC
 
 # TODO PLOT THAT

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -20,6 +20,7 @@ check_options(opt)
 
 # load libraries
 suppressMessages(source(here::here("load_packages.R")))
+source(here::here("util", "normalization_functions.R"))
 source(here::here("util", "color_blind_friendly_palette.R"))
 
 # set options
@@ -102,8 +103,8 @@ doParallel::registerDoParallel(cl)
 # at each titration level (0-100% RNA-seq)
 perc_seq <- as.character(seq(0, 100, 10))
 norm_methods <- c("log", "npn", "qn", "tdm", "z")
-plier_results_list <- foreach(ps = perc_seq, .packages = c("PLIER", "doParallel")) %dopar% {
-  foreach(nm = norm_methods, .packages = c("PLIER", "doParallel")) %dopar% {
+plier_results_list <- foreach(ps = perc_seq, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
+  foreach(nm = norm_methods, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
 
     if (nm %in% names(norm.train.list[[ps]])){
       if(any(apply(norm.train.list[[ps]][[nm]], 1, check_all_same))) {

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -66,11 +66,10 @@ all.paths <- PLIER::combinePaths(bloodCellMarkersIRISDMAP,
 
 #### loop over data for each seed and get PLIER results ------------------------
 
-#for(seed_index in 1:length(norm.train.files)) {
-for(seed_index in 1:2) {
+for(seed_index in 1:length(norm.train.files)) {
   
-  print(str_c("PLIER with data seed", seed_index,
-              "out of", length(norm.train.files), "..."))
+  message(str_c("PLIER with data seed ", seed_index,
+                "out of ", length(norm.train.files), "..."))
   
   #### read in data ------------------------------------------------------------
   
@@ -111,10 +110,8 @@ for(seed_index in 1:2) {
   doParallel::registerDoParallel(cl)
   
   # at each titration level (0-100% RNA-seq)
-  #perc_seq <- as.character(seq(0, 100, 10))
-  #norm_methods <- c("log", "npn", "qn", "tdm", "z")
-  perc_seq <- as.character(seq(0, 100, 50))
-  norm_methods <- c("log", "z")
+  perc_seq <- as.character(seq(0, 100, 10))
+  norm_methods <- c("log", "npn", "qn", "tdm", "z")
   plier_results_list <- foreach(ps = perc_seq, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
     foreach(nm = norm_methods, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
       

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -24,7 +24,10 @@ else
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
 fi
 
-# Run the unsupervised analyses
-Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
-Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
-Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+# Run the unsupervised analyses using subtype models
+if [ $predictor == "subtype" ]; then
+  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
+  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type
+fi


### PR DESCRIPTION
 Branch 2 in the quest for PLIER comparison metrics! re: https://github.com/greenelab/RNAseq_titration_results/issues/73

This branch adds the script `7-extract_plier_pathways.R`. Content in this PR focuses on the overall mechanics of running PLIER over all normalization methods, RNA-seq %s, and seeded files.

Highlights
- Lines 1-53 are highly similar to other scripts in this project, just getting set up
- PLIER action starts ~55 with establishing all the pathways
- There is a function to convert the gene column to row names as well as convert the type of gene name for GBM data (ENSG to symbol)
- Then comes running PLIER
  - Loop over seed index
  - Parallel over % RNA-seq and norm method
 
I'm seeing now that there are changes I made in the next branch that more closely align with the purpose of this branch. For example, I've highlighted some TODOs that I later resolve, but which have more to do with running PLIER than calculating Jaccard. I also know that determining the common gene set got moved to the inner most parallel step to allow for different sets of common genes per data set, but that shouldn't be necessary in practice.

The next branch hosts the more finalized PLIER loop and jaccard measuring...