### PR TITLE
Envest/73 plier 03 jaccard metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ data
 normalized_data
 models
 results/reconstructed_data
+.Rproj.user
+RNAseq_titration_results.Rproj

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -198,7 +198,7 @@ for(seed_index in 1:length(norm.train.files)) {
                                      all.paths[common.genes, ],
                                      k = set.k,
                                      scale = FALSE),
-                 error = function(err) NA)
+                 error = function(err) message("hmmm"))
         
       } else {
         

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -162,8 +162,8 @@ for(seed_index in 1:length(norm.train.files)) {
   perc_seq <- as.character(seq(0, 100, 50))
   norm_methods <- c("log", "z")
   plier_results_list <- foreach(ps = perc_seq,
-                                .packages = c("PLIER", "doParallel"),
-                                .export = c("check_all_same")) %dopar% {
+                                #.export = c("check_all_same")
+                                .packages = c("PLIER", "doParallel")) %dopar% {
     foreach(nm = norm_methods) %dopar% { #}, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
       
       if (nm %in% names(norm.train.list[[ps]])) {

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -8,10 +8,12 @@
 option_list <- list(
   optparse::make_option("--cancer_type",
                         default = NA_character_,
-                        help = "Cancer type"),
+                        help = "Cancer type"
+  ),
   optparse::make_option("--seed",
                         default = 8934,
-                        help = "Random seed")
+                        help = "Random seed"
+  )
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list = option_list))
@@ -38,15 +40,20 @@ norm.data.dir <- here::here("normalized_data")
 res.dir <- here::here("results")
 
 # define input files
-#norm.test.files <- file.path(norm.data.dir,
+# norm.test.files <- file.path(norm.data.dir,
 #                            list.files(norm.data.dir,
 #                                       pattern = paste0(file_identifier,
 #                                                        "_array_seq_test_data_normalized_list_")))
-norm.train.files <- file.path(norm.data.dir,
-                             list.files(norm.data.dir,
-                                        pattern = paste0(file_identifier,
-                                                         "_array_seq_train_titrate_normalized_list_")))
-#sample.files <- file.path(res.dir,
+norm.train.files <- file.path(
+  norm.data.dir,
+  list.files(norm.data.dir,
+             pattern = paste0(
+               file_identifier,
+               "_array_seq_train_titrate_normalized_list_"
+             )
+  )
+)
+# sample.files <- file.path(res.dir,
 #                         list.files(res.dir,
 #                                    pattern = paste0(file_identifier,
 #                                                     "_matchedSamples_training_testing_split_labels_")))
@@ -58,14 +65,16 @@ data(canonicalPathways)
 data(oncogenicPathways)
 data(svmMarkers)
 
-all.paths <- PLIER::combinePaths(bloodCellMarkersIRISDMAP,
-                                 canonicalPathways,
-                                 oncogenicPathways,
-                                 svmMarkers)
+all.paths <- PLIER::combinePaths(
+  bloodCellMarkersIRISDMAP,
+  canonicalPathways,
+  oncogenicPathways,
+  svmMarkers
+)
 
 #### Function for converting column to row names -------------------------------
 
-convert_row_names <- function(expr, cancer_type){
+convert_row_names <- function(expr, cancer_type) {
   # If the cancer type is GBM, convert ENSG to gene symbols
   # then convert the gene column to rownames
   #
@@ -77,17 +86,18 @@ convert_row_names <- function(expr, cancer_type){
       mutate(gene = ensembldb::select(EnsDb.Hsapiens.v86::EnsDb.Hsapiens.v86,
                                       keys = as.character(gene),
                                       keytype = "GENEID",
-                                      columns = "SYMBOL")$SYMBOL)
+                                      columns = "SYMBOL"
+      )$SYMBOL)
   }
   
   column_to_rownames(expr,
-                     var = "gene")
-  
+                     var = "gene"
+  )
 }
 
 #### Function to get jaccard values from a list of PLIER results ---------------
 
-return_plier_jaccard <- function(test_PLIER, array_silver, seq_silver){
+return_plier_jaccard <- function(test_PLIER, array_silver, seq_silver) {
   # Given a set of PLIER results (which is a list), compare significant pathways
   # to two silver sets of pathways defined by array and RNA-seq data only
   # Jaccard similaritiy is defined as O(intersect)/O(union).
@@ -100,45 +110,60 @@ return_plier_jaccard <- function(test_PLIER, array_silver, seq_silver){
     pull(pathway) %>%
     unique()
   
-  array_jaccard <- length(intersect(array_silver, test_pathways))/length(union(array_silver, test_pathways))
-  seq_jaccard <- length(intersect(seq_silver, test_pathways))/length(union(seq_silver, test_pathways))  
+  array_jaccard <- length(intersect(array_silver, test_pathways)) / length(union(array_silver, test_pathways))
+  seq_jaccard <- length(intersect(seq_silver, test_pathways)) / length(union(seq_silver, test_pathways))
   
-  data.frame(silver = c("array", "seq"),
-             n_silver = c(length(array_silver),
-                          length(seq_silver)),
-             n_test = length(test_pathways),
-             n_intersect = c(length(intersect(array_silver, test_pathways)),
-                             length(intersect(seq_silver, test_pathways))),
-             n_union = c(length(union(array_silver, test_pathways)),
-                         length(union(seq_silver, test_pathways))),
-             n_common_genes = nrow(test_PLIER[["Z"]]),
-             k = ncol(test_PLIER[["Z"]]),
-             jaccard = c(array_jaccard,
-                         seq_jaccard))
-  
+  data.frame(
+    silver = c("array", "seq"),
+    n_silver = c(
+      length(array_silver),
+      length(seq_silver)
+    ),
+    n_test = length(test_pathways),
+    n_intersect = c(
+      length(intersect(array_silver, test_pathways)),
+      length(intersect(seq_silver, test_pathways))
+    ),
+    n_union = c(
+      length(union(array_silver, test_pathways)),
+      length(union(seq_silver, test_pathways))
+    ),
+    n_common_genes = nrow(test_PLIER[["Z"]]),
+    k = ncol(test_PLIER[["Z"]]),
+    jaccard = c(
+      array_jaccard,
+      seq_jaccard
+    )
+  )
 }
 
 #### loop over data for each seed and get PLIER results ------------------------
 
 jaccard_list <- list()
 
-for(seed_index in 1:length(norm.train.files)) {
-  
+for (seed_index in 1:length(norm.train.files)) {
   message(str_c("PLIER with data seed", seed_index,
                 "out of", length(norm.train.files), "...",
-                sep = " "))
+                sep = " "
+  ))
   
   #### read in data ------------------------------------------------------------
   
-  #norm.test.list <- read_rds(norm.test.files[seed_index])
+  # norm.test.list <- read_rds(norm.test.files[seed_index])
   norm.train.list <- read_rds(norm.train.files[seed_index])
-  #sample.df <- read.delim(sample.files[seed_index])
+  # sample.df <- read.delim(sample.files[seed_index])
   
   # convert gene names column to row names
   # if GBM, also convert from GENEID to SYMBOL
-  norm.train.list <- purrr::modify_depth(norm.train.list, 2,
-                                         function(x) convert_row_names(expr = x,
-                                                                       cancer_type = cancer_type))
+  norm.train.list <- purrr::modify_depth(
+    norm.train.list, 2,
+    function(x) {
+      convert_row_names(
+        expr = x,
+        cancer_type = cancer_type
+      )
+    }
+  )
   
   #### main --------------------------------------------------------------------
   
@@ -150,43 +175,46 @@ for(seed_index in 1:length(norm.train.files)) {
   doParallel::registerDoParallel(cl)
   
   # at each titration level (0-100% RNA-seq)
-  #perc_seq <- as.character(seq(0, 100, 10))
-  #norm_methods <- c("log", "npn", "qn", "tdm", "z")
+  # perc_seq <- as.character(seq(0, 100, 10))
+  # norm_methods <- c("log", "npn", "qn", "tdm", "z")
   perc_seq <- as.character(seq(0, 100, 50))
   norm_methods <- c("log", "qn")
-  plier_results_list <- foreach(ps = perc_seq,
-                                .packages = c("PLIER", "doParallel")) %dopar% {
+  plier_results_list <- foreach(
+    ps = perc_seq,
+    .packages = c("PLIER", "doParallel")
+  ) %dopar% {
     foreach(nm = norm_methods) %dopar% {
-      
       if (nm %in% names(norm.train.list[[ps]])) {
         
         # remove any rows with all the same value
         # TODO this may now be superfluous given fixed 0-1 rescaling issue
-        all.same.indx <- which(apply(norm.train.list[[ps]][[nm]], 1,
-                                     check_all_same))
+        all.same.indx <- which(apply(
+          norm.train.list[[ps]][[nm]], 1,
+          check_all_same
+        ))
         if (length(all.same.indx) > 0) {
           norm.train.list[[ps]][[nm]] <- norm.train.list[[ps]][[nm]][-all.same.indx, ]
         }
         
         # get common genes
-        common.genes <- PLIER::commonRows(all.paths,
-                                          norm.train.list[[ps]][[nm]])      
+        common.genes <- PLIER::commonRows(
+          all.paths,
+          norm.train.list[[ps]][[nm]]
+        )
         
         # minimum k for PLIER = 2*num.pc
-        set.k <- 2*PLIER::num.pc(PLIER::rowNorm(norm.train.list[[ps]][[nm]][common.genes, ]))
+        set.k <- 2 * PLIER::num.pc(PLIER::rowNorm(norm.train.list[[ps]][[nm]][common.genes, ]))
         # TODO alternatively, should we just set one k for all data sets? e.g.
-        #set.k <- 50 # set k the be the same arbitrary value for all runs
+        # set.k <- 50 # set k the be the same arbitrary value for all runs
         
         # PLIER main function
         PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
                      all.paths[common.genes, ],
                      k = set.k,
-                     scale = TRUE) # PLIER z-scores input values by row
-
+                     scale = TRUE
+        ) # PLIER z-scores input values by row
       } else {
-        
         NULL # return NULL for empty result; purrr will ignore this list element
-        
       }
     }
   }
@@ -213,38 +241,46 @@ for(seed_index in 1:length(norm.train.files)) {
   
   # Check that silver standard pathways have non-zero length
   if (length(array_silver) > 0 & length(seq_silver) > 0) {
-  
+    
     # Return pathway comparison for appropriate level of PLIER results list
-    jaccard_list[[seed_index]] <- purrr::modify_depth(plier_results_list, 2,
-                                                      function(x) return_plier_jaccard(x, array_silver, seq_silver))
-    
+    jaccard_list[[seed_index]] <- purrr::modify_depth(
+      plier_results_list, 2,
+      function(x) return_plier_jaccard(x, array_silver, seq_silver)
+    )
   } else {
-    
     message(str_c("PLIER: Silver standard array or seq significant pathways has zero length",
                   seed_index, percent_seq, normalization_method,
                   length(array_silver), length(seq_silver),
-                  sep = " "))
-    
+                  sep = " "
+    ))
   }
 }
 
 if (length(jaccard_list) > 0) {
   
   # melt jaccard list elements into one data frame
-  jaccard_df <- reshape2::melt(data = jaccard_list,
-                               id.vars = c("silver", "n_silver", "n_test",
-                                           "n_intersect", "n_union",
-                                           "n_common_genes", "k"),
-                               value.name = "jaccard") %>%
-    rename("nmeth" = "L3", # normalization method
-           "pseq" = "L2", # percentage RNA-seq
-           "seed_index" = "L1")
+  jaccard_df <- reshape2::melt(
+    data = jaccard_list,
+    id.vars = c(
+      "silver", "n_silver", "n_test",
+      "n_intersect", "n_union",
+      "n_common_genes", "k"
+    ),
+    value.name = "jaccard"
+  ) %>%
+    rename(
+      "nmeth" = "L3", # normalization method
+      "pseq" = "L2", # percentage RNA-seq
+      "seed_index" = "L1"
+    )
   
-  readr::write_tsv(x = jaccard_df,
-                   path = file.path(res.dir,
-                                    str_c(file_identifier, "_PLIER_jaccard.tsv")))
+  readr::write_tsv(
+    x = jaccard_df,
+    path = file.path(
+      res.dir,
+      str_c(file_identifier, "_PLIER_jaccard.tsv")
+    )
+  )
   
   # TODO PLOT THAT
 }
-  
-  

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -84,8 +84,9 @@ jaccard_list <- list()
 
 for(seed_index in 1:length(norm.train.files)) {
   
-  message(str_c("PLIER with data seed ", seed_index,
-                "out of ", length(norm.train.files), "..."))
+  message(str_c("PLIER with data seed", seed_index,
+                "out of", length(norm.train.files), "...",
+                sep = " "))
   
   #### read in data ------------------------------------------------------------
   
@@ -114,8 +115,10 @@ for(seed_index in 1:length(norm.train.files)) {
   doParallel::registerDoParallel(cl)
   
   # at each titration level (0-100% RNA-seq)
-  perc_seq <- as.character(seq(0, 100, 10))
-  norm_methods <- c("log", "npn", "qn", "tdm", "z")
+  #perc_seq <- as.character(seq(0, 100, 10))
+  #norm_methods <- c("log", "npn", "qn", "tdm", "z")
+  perc_seq <- as.character(seq(0, 100, 50))
+  norm_methods <- c("log", "z")
   plier_results_list <- foreach(ps = perc_seq, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
     foreach(nm = norm_methods, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
       

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -193,12 +193,12 @@ for(seed_index in 1:length(norm.train.files)) {
         message(min(apply(norm.train.list[[ps]][[nm]], 1, sd)))
         message(nrow(all.paths[common.genes, ]))
         # PLIER main function
-        
-        tryCatch(expr = PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
-                                     all.paths[common.genes, ],
-                                     k = set.k,
-                                     scale = FALSE),
-                 error = function(err) message("hmmm"))
+        if (ps != "100" & nm != "z") {
+          PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
+                       all.paths[common.genes, ],
+                       k = set.k,
+                       scale = FALSE)  
+        }
         
       } else {
         
@@ -225,12 +225,12 @@ for(seed_index in 1:length(norm.train.files)) {
                    path = str_c("plier_results_list.", seed_index, ".RDS"))
   
   # Jaccard comparison metric to array and seq silver standards
-  # TODO what are best settings for silver standard? PLIER expects z-scored
-  array_silver <- plier_results_list[["0"]][["z"]][["summary"]] %>%
+  # TODO what are best settings for silver standard?
+  array_silver <- plier_results_list[["0"]][["log"]][["summary"]] %>%
     filter(FDR < 0.05) %>%
     pull(pathway) %>%
     unique()
-  seq_silver <- plier_results_list[["100"]][["z"]][["summary"]] %>%
+  seq_silver <- plier_results_list[["100"]][["log"]][["summary"]] %>%
     filter(FDR < 0.05) %>%
     pull(pathway) %>%
     unique()

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -193,10 +193,12 @@ for(seed_index in 1:length(norm.train.files)) {
         message(min(apply(norm.train.list[[ps]][[nm]], 1, sd)))
         message(nrow(all.paths[common.genes, ]))
         # PLIER main function
-        PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
-                     all.paths[common.genes, ],
-                     k = set.k,
-                     scale = FALSE)
+        
+        tryCatch(expr = PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
+                                     all.paths[common.genes, ],
+                                     k = set.k,
+                                     scale = FALSE),
+                 error = function(err) NA)
         
       } else {
         

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -173,7 +173,7 @@ for(seed_index in 1:length(norm.train.files)) {
                                           norm.train.list[[ps]][[nm]])      
         
         # minimum k for PLIER = 2*num.pc
-        set.k <- 2*PLIER::num.pc(norm.train.list[[ps]][[nm]][common.genes, ])
+        set.k <- 2*PLIER::num.pc(PLIER::rowNorm(norm.train.list[[ps]][[nm]][common.genes, ]))
         # TODO alternatively, should we just set one k for all data sets? e.g.
         #set.k <- 50 # set k the be the same arbitrary value for all runs
         

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -1,6 +1,6 @@
 # Steven Foltz Nov 2021
 # The purpose of this analysis is to use PLIER to identify expression pathways
-# in our data, using pure microarray and RNA-seq data as comparison standards
+# in our data, and quantify the rate of return for significant PLIER pathways
 # for data coming from different normalization methods and titration levels.
 #
 # USAGE: Rscript 7-extract_plier_pathways.R --cancer_type --seed
@@ -38,12 +38,9 @@ message(paste("\nPLIER initial seed set to:", initial.seed))
 data.dir <- here::here("data")
 norm.data.dir <- here::here("normalized_data")
 res.dir <- here::here("results")
+plots.dir <- here::here("plots")
 
 # define input files
-# norm.test.files <- file.path(norm.data.dir,
-#                            list.files(norm.data.dir,
-#                                       pattern = paste0(file_identifier,
-#                                                        "_array_seq_test_data_normalized_list_")))
 norm.train.files <- file.path(
   norm.data.dir,
   list.files(norm.data.dir,
@@ -53,10 +50,6 @@ norm.train.files <- file.path(
              )
   )
 )
-# sample.files <- file.path(res.dir,
-#                         list.files(res.dir,
-#                                    pattern = paste0(file_identifier,
-#                                                     "_matchedSamples_training_testing_split_labels_")))
 
 #### set up PLIER data ---------------------------------------------------------
 
@@ -71,6 +64,8 @@ all.paths <- PLIER::combinePaths(
   oncogenicPathways,
   svmMarkers
 )
+
+PLIER_pathways <- colnames(all.paths)
 
 #### Function for converting column to row names -------------------------------
 
@@ -95,46 +90,122 @@ convert_row_names <- function(expr, cancer_type) {
   )
 }
 
-#### Function to get jaccard values from a list of PLIER results ---------------
+#### Failure of PLIER to converge may manifest in different error messages...
 
-return_plier_jaccard <- function(test_PLIER, array_silver, seq_silver) {
+check_plier_failure_to_converge <- function(plier_result) {
+
+  # if the plier result contained an error message
+  if ("message" %in% names(plier_result)) {
+    # and if that error massage refers to convergence failure directly or indirectly
+    if (str_detect(plier_result$message, "system is computationally singular") | 
+        str_detect(plier_result$message, "subscript out of bounds")) {
+      NA # return NA
+    } else { # PLIER failed for another reason and we need to know about that
+      stop("PLIER run failed for reason other than system is computationally singular")
+    }
+  } else {
+    plier_result # return the plier result as is
+  }
+}
+
+#### Functions to get jaccard values from a list of PLIER results ---------------
+
+return_plier_jaccard_silver <- function(test_PLIER, array_silver, seq_silver) {
   # Given a set of PLIER results (which is a list), compare significant pathways
   # to two silver sets of pathways defined by array and RNA-seq data only
-  # Jaccard similaritiy is defined as O(intersect)/O(union).
-  #
+  # Jaccard similarity is defined as O(intersect)/O(union). If the input is not
+  # a properly completed PLIER result, then return all NAs.
+  # 
   # Inputs: PLIER result, pathway set 1, pathway set 2
   # Returns: data frame with two rows (array, seq) with stats for each overlap
   
-  test_pathways <- test_PLIER[["summary"]] %>%
-    filter(FDR < 0.05) %>%
-    pull(pathway) %>%
-    unique()
-  
-  array_jaccard <- length(intersect(array_silver, test_pathways)) / length(union(array_silver, test_pathways))
-  seq_jaccard <- length(intersect(seq_silver, test_pathways)) / length(union(seq_silver, test_pathways))
-  
-  data.frame(
-    silver = c("array", "seq"),
-    n_silver = c(
-      length(array_silver),
-      length(seq_silver)
-    ),
-    n_test = length(test_pathways),
-    n_intersect = c(
-      length(intersect(array_silver, test_pathways)),
-      length(intersect(seq_silver, test_pathways))
-    ),
-    n_union = c(
-      length(union(array_silver, test_pathways)),
-      length(union(seq_silver, test_pathways))
-    ),
-    n_common_genes = nrow(test_PLIER[["Z"]]),
-    k = ncol(test_PLIER[["Z"]]),
-    jaccard = c(
-      array_jaccard,
-      seq_jaccard
+  if ("summary" %in% names(test_PLIER)) {
+    
+    test_pathways <- test_PLIER[["summary"]] %>%
+      filter(FDR < 0.05) %>%
+      pull(pathway) %>%
+      unique()
+    
+    array_jaccard <- length(intersect(array_silver, test_pathways)) / length(union(array_silver, test_pathways))
+    seq_jaccard <- length(intersect(seq_silver, test_pathways)) / length(union(seq_silver, test_pathways))
+    
+    data.frame(
+      silver = c("array", "seq"),
+      n_silver = c(
+        length(array_silver),
+        length(seq_silver)
+      ),
+      n_test = length(test_pathways),
+      n_intersect = c(
+        length(intersect(array_silver, test_pathways)),
+        length(intersect(seq_silver, test_pathways))
+      ),
+      n_union = c(
+        length(union(array_silver, test_pathways)),
+        length(union(seq_silver, test_pathways))
+      ),
+      n_common_genes = nrow(test_PLIER[["Z"]]),
+      k = ncol(test_PLIER[["Z"]]),
+      jaccard = c(
+        array_jaccard,
+        seq_jaccard
+      )
     )
-  )
+  } else {
+    
+    data.frame(
+      silver = NA,
+      n_silver = NA,
+      n_test = NA,
+      n_intersect = NA,
+      n_union = NA,
+      n_common_genes = NA,
+      k = NA,
+      jaccard = NA
+    )  
+    
+  }
+}
+
+return_plier_jaccard_global <- function(test_PLIER, global_pathways) {
+  # Given a set of PLIER results (which is a list), compare significant pathways
+  # to a global set of pathways defined by the existing PLIER pathways
+  # Jaccard similarity is defined as O(intersect)/O(union). If the input is not
+  # a properly completed PLIER result, then return all NAs.
+  #
+  # Inputs: PLIER result, global pathways
+  # Returns: data frame with one row with stats for each overlap
+  
+  if ("summary" %in% names(test_PLIER)) {
+    
+    test_pathways <- test_PLIER[["summary"]] %>%
+      filter(FDR < 0.05) %>%
+      pull(pathway) %>%
+      unique()
+    
+    global_jaccard <- length(intersect(global_pathways, test_pathways)) / length(global_pathways)
+    
+    data.frame(
+      n_global = length(global_pathways),
+      n_test = length(test_pathways),
+      n_intersect = length(intersect(global_pathways, test_pathways)),
+      n_common_genes = nrow(test_PLIER[["Z"]]),
+      k = ncol(test_PLIER[["Z"]]),
+      jaccard = global_jaccard
+    ) 
+    
+  } else {
+    
+    data.frame(
+      n_global = NA,
+      n_test = NA,
+      n_intersect = NA,
+      n_common_genes = NA,
+      k = NA,
+      jaccard = NA
+    )
+    
+  }
 }
 
 #### loop over data for each seed and get PLIER results ------------------------
@@ -149,9 +220,7 @@ for (seed_index in 1:length(norm.train.files)) {
   
   #### read in data ------------------------------------------------------------
   
-  # norm.test.list <- read_rds(norm.test.files[seed_index])
   norm.train.list <- read_rds(norm.train.files[seed_index])
-  # sample.df <- read.delim(sample.files[seed_index])
   
   # convert gene names column to row names
   # if GBM, also convert from GENEID to SYMBOL
@@ -164,54 +233,87 @@ for (seed_index in 1:length(norm.train.files)) {
       )
     }
   )
-  
+
   #### main --------------------------------------------------------------------
   
+  # parallel backend
+  cl <- parallel::makeCluster(floor(detectCores()/2))
+  doParallel::registerDoParallel(cl)
+
   # create an output list
   plier_results_list <- list()
   
-  # parallel backend
-  cl <- parallel::makeCluster(detectCores() - 1)
-  doParallel::registerDoParallel(cl)
+  # at different titration levels (0-100% RNA-seq) and normalization methods
+  # generate the PLIER results for array alone, seq alone, and array + seq combo
   
-  # at each titration level (0-100% RNA-seq)
-  # perc_seq <- as.character(seq(0, 100, 10))
-  # norm_methods <- c("log", "npn", "qn", "tdm", "z")
   perc_seq <- as.character(seq(0, 100, 50))
-  norm_methods <- c("log", "qn")
+  norm_methods_if_0_100 <- c("log")
+  norm_methods_else <- c("log", "npn", "qn", "qn-z", "tdm", "z",
+                         "array_only", "seq_only")
+
   plier_results_list <- foreach(
     ps = perc_seq,
     .packages = c("PLIER", "doParallel")
-  ) %dopar% {
-    foreach(nm = norm_methods) %dopar% {
+  ) %do% {
+    message(str_c("  PLIER at ", ps, "% RNA-seq"))
+
+    if (ps %in% c("0", "100")) { # no need to add array_only or seq_only
+
+      norm_methods <- norm_methods_if_0_100
+
+    } else {
+
+      norm_methods <- norm_methods_else
+
+      # get array and seq sample columns     
+      array_only_columns_tf <- names(norm.train.list[["0"]][["log"]]) %in%
+        names(norm.train.list[[ps]][["raw.array"]])
+
+      seq_only_columns_tf <- !array_only_columns_tf
+
+      # add array only and seq only data to each % RNA-seq
+      norm.train.list[[ps]][["array_only"]] <- norm.train.list[["0"]][["log"]][,array_only_columns_tf]
+      norm.train.list[[ps]][["seq_only"]] <- norm.train.list[["100"]][["log"]][,seq_only_columns_tf]
+
+    }
+
+    foreach(
+      nm = norm_methods,
+      .packages = c("PLIER", "doParallel"),
+      .errorhandling = "pass" # let pass on inside loop
+    ) %dopar% {
+
       if (nm %in% names(norm.train.list[[ps]])) {
-        
+
         # remove any rows with all the same value
         all.same.indx <- which(apply(
           norm.train.list[[ps]][[nm]], 1,
           check_all_same
         ))
+
         if (length(all.same.indx) > 0) {
           norm.train.list[[ps]][[nm]] <- norm.train.list[[ps]][[nm]][-all.same.indx, ]
         }
-        
+
         # get common genes
         common.genes <- PLIER::commonRows(
           all.paths,
           norm.train.list[[ps]][[nm]]
         )
-        
+
         # minimum k for PLIER = 2*num.pc
         set.k <- 2 * PLIER::num.pc(PLIER::rowNorm(norm.train.list[[ps]][[nm]][common.genes, ]))
-        
+
         # PLIER main function
         PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
                      all.paths[common.genes, ],
                      k = set.k,
-                     scale = TRUE
-        ) # PLIER z-scores input values by row
+                     scale = TRUE # PLIER z-scores input values by row
+        )
+
       } else {
-        NULL # return NULL for empty result; purrr will ignore this list element
+
+        NA # NA for no data at this ps nm combination (0% and 100% TDM)
       }
     }
   }
@@ -222,35 +324,24 @@ for (seed_index in 1:length(norm.train.files)) {
   # renames list levels
   names(plier_results_list) <- perc_seq
   for (i in perc_seq) {
-    names(plier_results_list[[i]]) <- norm_methods
+    if (i %in% c("0", "100")) {
+      names(plier_results_list[[i]]) <- norm_methods_if_0_100
+    } else {
+      names(plier_results_list[[i]]) <- norm_methods_else
+    }
   }
   
-  # Set  array and seq silver standards for Jaccard comparison metric
-  # TODO what are best settings for silver standard?
-  array_silver <- plier_results_list[["0"]][["log"]][["summary"]] %>%
-    filter(FDR < 0.05) %>%
-    pull(pathway) %>%
-    unique()
-  seq_silver <- plier_results_list[["100"]][["log"]][["summary"]] %>%
-    filter(FDR < 0.05) %>%
-    pull(pathway) %>%
-    unique()
+  # Check for failure to converge, and set to NA
+  plier_results_list <- purrr::modify_depth(plier_results_list, 2,
+                                            check_plier_failure_to_converge
+  )
   
-  # Check that silver standard pathways have non-zero length
-  if (length(array_silver) > 0 & length(seq_silver) > 0) {
-    
-    # Return pathway comparison for appropriate level of PLIER results list
-    jaccard_list[[seed_index]] <- purrr::modify_depth(
-      plier_results_list, 2,
-      function(x) return_plier_jaccard(x, array_silver, seq_silver)
-    )
-  } else {
-    message(str_c("PLIER: Silver standard array or seq significant pathways has zero length",
-                  seed_index, percent_seq, normalization_method,
-                  length(array_silver), length(seq_silver),
-                  sep = " "
-    ))
-  }
+  # Return pathway comparison for appropriate level of PLIER results list
+  jaccard_list[[seed_index]] <- purrr::modify_depth(
+    plier_results_list, 2,
+    function(x) return_plier_jaccard_global(x, PLIER_pathways)
+  )
+  
 }
 
 if (length(jaccard_list) > 0) {
@@ -259,8 +350,7 @@ if (length(jaccard_list) > 0) {
   jaccard_df <- reshape2::melt(
     data = jaccard_list,
     id.vars = c(
-      "silver", "n_silver", "n_test",
-      "n_intersect", "n_union",
+      "n_global", "n_test", "n_intersect",
       "n_common_genes", "k"
     ),
     value.name = "jaccard"
@@ -279,5 +369,34 @@ if (length(jaccard_list) > 0) {
     )
   )
   
-  # TODO PLOT THAT
+  # Plot results
+  
+  plot_filename = file.path(
+    plots.dir,
+    str_c(file_identifier, "_PLIER_jaccard.pdf")
+  )
+  
+  jaccard_df %>%
+    mutate(pseq = as.factor(pseq),
+           nmeth = str_to_upper(nmeth)) %>%
+    ggplot(aes(x = pseq,
+               y = jaccard)) +
+    geom_violin() +
+    stat_summary(fun = median, geom = "line", aes(group = "pseq"),
+                 position = position_dodge(0.6)) +
+    stat_summary(fun = median, geom = "point", aes(group = "pseq"),
+                 position = position_dodge(0.7), size = 1) +
+    expand_limits(y = 0) +
+    facet_wrap(~ nmeth,
+               nrow = 1) +
+    ggtitle(cancer_type) +
+    xlab("% RNA-seq samples") +
+    ylab("Proportion") +
+    theme_bw() +
+    theme(text = element_text(size = 18)) +
+    theme(axis.text.x = element_text(angle = 45, vjust = 0.5))
+  
+  ggsave(plot_filename,
+         plot = last_plot(),
+         height = 3.5, width = 15)
 }

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -217,6 +217,9 @@ for(seed_index in 1:length(norm.train.files)) {
     names(plier_results_list[[i]]) <- norm_methods
   }
   
+  
+  print(plier_results_list)
+  
   # TODO remove this test: write out plier results
   readr::write_rds(x = plier_results_list,
                    path = str_c("plier_results_list.", seed_index, ".RDS"))

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -193,7 +193,9 @@ for(seed_index in 1:length(norm.train.files)) {
         message(min(apply(norm.train.list[[ps]][[nm]], 1, sd)))
         message(nrow(all.paths[common.genes, ]))
         # PLIER main function
-        if (ps != "100" & nm != "z") {
+        if (ps == "100" & nm == "z") {
+          NA
+        } else {
           PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
                        all.paths[common.genes, ],
                        k = set.k,

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -162,18 +162,22 @@ for(seed_index in 1:length(norm.train.files)) {
   perc_seq <- as.character(seq(0, 100, 50))
   norm_methods <- c("log", "z")
   plier_results_list <- foreach(ps = perc_seq,
-                                #.export = c("check_all_same")
-                                .packages = c("PLIER", "doParallel")) %dopar% {
-    foreach(nm = norm_methods) %dopar% { #}, .packages = c("PLIER", "doParallel"), .export = c("check_all_same")) %dopar% {
+                                .packages = c("PLIER", "doParallel")) %do% { #par% {
+    foreach(nm = norm_methods) %do% { #par% {
       
       if (nm %in% names(norm.train.list[[ps]])) {
         
+        message(c(seed_index, ps, nm))
+        
         # remove any rows with all the same value
         all.same.indx <- which(apply(norm.train.list[[ps]][[nm]], 1,
-                               check_all_same))
+                                     check_all_same))
+        message(length(all.same.indx))
+        message(nrow(norm.train.list[[ps]][[nm]]))
         if (length(all.same.indx) > 0) {
           norm.train.list[[ps]][[nm]] <- norm.train.list[[ps]][[nm]][-all.same.indx, ]
         }
+        message(nrow(norm.train.list[[ps]][[nm]]))
         
         # get common genes
         common.genes <- PLIER::commonRows(all.paths,
@@ -188,7 +192,6 @@ for(seed_index in 1:length(norm.train.files)) {
         PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
                      all.paths[common.genes, ],
                      k = set.k,
-                     trace = FALSE,
                      scale = FALSE)
         
       } else {

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -167,7 +167,7 @@ for(seed_index in 1:length(norm.train.files)) {
       
       if (nm %in% names(norm.train.list[[ps]])) {
         
-        message(c(seed_index, ps, nm))
+        message(str_c(seed_index, ps, nm, sep = " "))
         
         # remove any rows with all the same value
         all.same.indx <- which(apply(norm.train.list[[ps]][[nm]], 1,
@@ -182,12 +182,16 @@ for(seed_index in 1:length(norm.train.files)) {
         # get common genes
         common.genes <- PLIER::commonRows(all.paths,
                                           norm.train.list[[ps]][[nm]])      
+        message(length(common.genes))
         
         # minimum k for PLIER = 2*num.pc
         set.k <- 2*PLIER::num.pc(norm.train.list[[ps]][[nm]][common.genes, ])
         # TODO alternatively, should we just set one k for all data sets?
         #set.k <- 50 # set k the be the same arbitrary value for all runs
-        
+        message(set.k)
+        message(nrow(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ])))
+        message(min(apply(norm.train.list[[ps]][[nm]], 1, sd)))
+        message(nrow(all.paths[common.genes, ]))
         # PLIER main function
         PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
                      all.paths[common.genes, ],

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -193,15 +193,11 @@ for(seed_index in 1:length(norm.train.files)) {
         message(min(apply(norm.train.list[[ps]][[nm]], 1, sd)))
         message(nrow(all.paths[common.genes, ]))
         # PLIER main function
-        if (ps == "100" & nm == "z") {
-          NA
-        } else {
-          PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
-                       all.paths[common.genes, ],
-                       k = set.k,
-                       scale = FALSE)  
-        }
-        
+        PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
+                     all.paths[common.genes, ],
+                     k = set.k,
+                     scale = TRUE)  
+
       } else {
         
         NA # return NA for easy check later 
@@ -218,9 +214,6 @@ for(seed_index in 1:length(norm.train.files)) {
   for (i in perc_seq) {
     names(plier_results_list[[i]]) <- norm_methods
   }
-  
-  
-  print(plier_results_list)
   
   # TODO remove this test: write out plier results
   readr::write_rds(x = plier_results_list,

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -95,22 +95,22 @@ return_plier_jaccard <- function(test_PLIER, array_silver, seq_silver){
   # Inputs: PLIER result, pathway set 1, pathway set 2
   # Returns: data frame with two rows (array, seq) with stats for each overlap
   
-  test_genes <- test_PLIER[["summary"]] %>%
+  test_pathways <- test_PLIER[["summary"]] %>%
     filter(FDR < 0.05) %>%
     pull(pathway) %>%
     unique()
   
-  array_jaccard <- length(intersect(array_silver, test_genes))/length(union(array_silver, test_genes))
-  seq_jaccard <- length(intersect(seq_silver, test_genes))/length(union(seq_silver, test_genes))  
+  array_jaccard <- length(intersect(array_silver, test_pathways))/length(union(array_silver, test_pathways))
+  seq_jaccard <- length(intersect(seq_silver, test_pathways))/length(union(seq_silver, test_pathways))  
   
   data.frame(silver = c("array", "seq"),
              n_silver = c(length(array_silver),
                           length(seq_silver)),
-             n_test = length(test_genes),
-             n_intersect = c(length(intersect(array_silver, test_genes)),
-                             length(intersect(seq_silver, test_genes))),
-             n_union = c(length(union(array_silver, test_genes)),
-                         length(union(seq_silver, test_genes))),
+             n_test = length(test_pathways),
+             n_intersect = c(length(intersect(array_silver, test_pathways)),
+                             length(intersect(seq_silver, test_pathways))),
+             n_union = c(length(union(array_silver, test_pathways)),
+                         length(union(seq_silver, test_pathways))),
              n_common_genes = nrow(test_PLIER[["Z"]]),
              k = ncol(test_PLIER[["Z"]]),
              jaccard = c(array_jaccard,

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -187,7 +187,6 @@ for (seed_index in 1:length(norm.train.files)) {
       if (nm %in% names(norm.train.list[[ps]])) {
         
         # remove any rows with all the same value
-        # TODO this may now be superfluous given fixed 0-1 rescaling issue
         all.same.indx <- which(apply(
           norm.train.list[[ps]][[nm]], 1,
           check_all_same
@@ -204,8 +203,6 @@ for (seed_index in 1:length(norm.train.files)) {
         
         # minimum k for PLIER = 2*num.pc
         set.k <- 2 * PLIER::num.pc(PLIER::rowNorm(norm.train.list[[ps]][[nm]][common.genes, ]))
-        # TODO alternatively, should we just set one k for all data sets? e.g.
-        # set.k <- 50 # set k the be the same arbitrary value for all runs
         
         # PLIER main function
         PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -24,7 +24,10 @@ else
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
 fi
 
-# Run the unsupervised analyses
-Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
-Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
-Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+# Run the unsupervised analyses using subtype models
+if [ $predictor == "subtype" ]; then
+  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
+  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type
+fi


### PR DESCRIPTION
The third branch in the PLIER saga returns to calculate similarity metrics with silver standard pathway sets. re: #73 

This branch
- Adds the function `return_plier_jaccard()` to return list of jaccard metrics in comparison to silver standards
  - Jaccard is calculated as the length of the intersect divided by the length of the union for two vectors of pathways
  - Other stats, like the number of LVs and the number of significant pathways are kept as well
- Sets silver standards (0% log for array, 100% log for seq) -- up for discussion
- Melts the jaccard list into something we can plot

Again, sorry that some changes in this branch focused is really more about effective PLIER usage. I appreciate the reviewer wading through it 😄 

When a few of the questions still present in the code are resolved, the next branch will focus on plotting the results.