### PR TITLE
Add UN and QN-Z data to train and test sets

### DIFF
--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -132,7 +132,9 @@ norm.titrate.list <- list()
 # single platform array normalization
 norm.titrate.list[["0"]] <-
   SinglePlatformNormalizationWrapper(titrate.mix.dt.list[[1]]$array,
-                                     platform = "array")
+                                     platform = "array",
+                                     add.untransformed = TRUE,
+                                     add.qn.z = TRUE)
 
 # parallel backend
 cl <- parallel::makeCluster(detectCores() - 1)
@@ -142,7 +144,9 @@ doParallel::registerDoParallel(cl)
 norm.titrate.list[2:10] <-
   foreach(n = 2:10) %dopar% {
     NormalizationWrapper(titrate.mix.dt.list[[n]]$array,
-                         titrate.mix.dt.list[[n]]$seq)
+                         titrate.mix.dt.list[[n]]$seq,
+                         add.untransformed = TRUE,
+                         add.qn.z = TRUE)
   }
 
 # stop parallel backend
@@ -153,7 +157,9 @@ names(norm.titrate.list)[2:10] <- names(titrate.mix.dt.list)[2:10]
 # single platform seq normalization
 norm.titrate.list[["100"]] <-
   SinglePlatformNormalizationWrapper(titrate.mix.dt.list[[11]]$seq,
-                                     platform = "seq")
+                                     platform = "seq",
+                                     add.untransformed = TRUE,
+                                     add.qn.z = TRUE)
 
 # save train data
 saveRDS(norm.titrate.list, file = file.path(norm.data.dir, norm.train.object))
@@ -167,7 +173,10 @@ seq.test <-
 
 # array normalization
 array.test.norm.list <-
-  SinglePlatformNormalizationWrapper(array.test, platform = "array")
+  SinglePlatformNormalizationWrapper(array.test,
+                                     platform = "array",
+                                     add.untransformed = TRUE,
+                                     add.qn.z = TRUE)
 
 # seq normalization
 # initialize list to hold normalized seq data
@@ -241,6 +250,12 @@ rm(seq.tdm.list)
 
 # z-score seq test data
 seq.test.norm.list[["z"]] <- ZScoreSingleDT(seq.test)
+
+# untransformed seq test data
+seq.test.norm.list[["un"]] <- seq.test
+
+# QN-Z seq test data
+seq.test.norm.list[["qn-z"]] <- QNZSingleDT(seq.test, zto)
 
 # combine array and seq test data into a list
 test.norm.list <- list(array = array.test.norm.list,

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -175,7 +175,7 @@ seq.test <-
 array.test.norm.list <-
   SinglePlatformNormalizationWrapper(array.test,
                                      platform = "array",
-                                     add.untransformed = TRUE,
+                                     add.untransformed = FALSE,
                                      add.qn.z = TRUE)
 
 # seq normalization
@@ -255,7 +255,7 @@ seq.test.norm.list[["z"]] <- ZScoreSingleDT(seq.test)
 seq.test.norm.list[["un"]] <- seq.test
 
 # QN-Z seq test data
-seq.test.norm.list[["qn-z"]] <- QNZSingleDT(seq.test, zto)
+seq.test.norm.list[["qn-z"]] <- QNZSingleDT(seq.test)
 
 # combine array and seq test data into a list
 test.norm.list <- list(array = array.test.norm.list,

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -133,7 +133,7 @@ norm.titrate.list <- list()
 norm.titrate.list[["0"]] <-
   SinglePlatformNormalizationWrapper(titrate.mix.dt.list[[1]]$array,
                                      platform = "array",
-                                     add.untransformed = FALSE,
+                                     add.untransformed = TRUE,
                                      add.qn.z = TRUE)
 
 # parallel backend
@@ -175,7 +175,7 @@ seq.test <-
 array.test.norm.list <-
   SinglePlatformNormalizationWrapper(array.test,
                                      platform = "array",
-                                     add.untransformed = FALSE,
+                                     add.untransformed = TRUE,
                                      add.qn.z = TRUE)
 
 # seq normalization

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -133,7 +133,7 @@ norm.titrate.list <- list()
 norm.titrate.list[["0"]] <-
   SinglePlatformNormalizationWrapper(titrate.mix.dt.list[[1]]$array,
                                      platform = "array",
-                                     add.untransformed = TRUE,
+                                     add.untransformed = FALSE,
                                      add.qn.z = TRUE)
 
 # parallel backend

--- a/2-train_test_category.R
+++ b/2-train_test_category.R
@@ -112,7 +112,8 @@ message(paste("Random seed for resampling:", resample.seed), appendLF=TRUE)
 
 train.model.list <-
   foreach(n = 1:length(restr.train.list)) %do% {  # foreach norm method
-    foreach(m = 1:length(category.norm.list)) %dopar% {  # foreach % seq level
+    foreach(m = 1:length(category.norm.list)) %do% { #par% {  # foreach % seq level
+      message(str_c(n, m, sep = " "))
       TrainThreeModels(dt = restr.train.list[[n]][[m]],
                        category = category.norm.list[[m]],
                        seed = resample.seed,
@@ -147,6 +148,7 @@ restr.train.list$tdm$`0` <- NULL
 restr.train.list$tdm$`100` <- NULL
 
 # get training kappa stats and write to file
+message("gets here 1")
 train.kappa.df <- PredictWrapper(train.model.list = train.model.list,
                                  pred.list = restr.train.list,
                                  sample.df = sample.train.test,
@@ -158,6 +160,7 @@ write.table(train.kappa.df, file = train.kappa.file, sep = "\t",
 #### predictions - test data ---------------------------------------------------
 
 # get predictions on array test data as a data frame
+message("gets here 2")
 array.kappa.df <- PredictWrapper(train.model.list = train.model.list,
                                  pred.list = norm.test.list$array,
                                  sample.df = sample.train.test,
@@ -177,6 +180,7 @@ for(i in 1:length(train.model.list[[5]])){
 norm.test.list$seq$tdm$`100` <- NULL
 
 # get predictions on RNA-seq test data as a data frame
+message("gets here 3")
 seq.kappa.df <- PredictWrapper(train.model.list = train.model.list,
                                pred.list = norm.test.list$seq,
                                sample.df = sample.train.test,

--- a/2-train_test_category.R
+++ b/2-train_test_category.R
@@ -168,9 +168,9 @@ write.table(array.kappa.df, file = array.kappa.file, sep = "\t",
 
 # for the 0 perc seq level of the titration, the model tested on log transformed
 # array data (100% array data) should be tested on the TDM transformed seq data
-for(i in 1:length(train.model.list[[5]])){
-  train.model.list[[5]][[i]]$`0` <- train.model.list[["log"]][[i]]$`0`
-  train.model.list[[5]][[i]] <- train.model.list[["tdm"]][[i]][c(10, 1:9)]
+for(i in 1:length(train.model.list[["tdm"]])){
+  train.model.list[["tdm"]][[i]]$`0` <- train.model.list[["log"]][[i]]$`0`
+  train.model.list[["tdm"]][[i]] <- train.model.list[["tdm"]][[i]][c(10, 1:9)]
 }
 
 # get rid of 100 tdm list, it's NULL

--- a/2-train_test_category.R
+++ b/2-train_test_category.R
@@ -112,8 +112,7 @@ message(paste("Random seed for resampling:", resample.seed), appendLF=TRUE)
 
 train.model.list <-
   foreach(n = 1:length(restr.train.list)) %do% {  # foreach norm method
-    foreach(m = 1:length(category.norm.list)) %do% { #par% {  # foreach % seq level
-      message(str_c(n, m, sep = " "))
+    foreach(m = 1:length(category.norm.list)) %dopar% {  # foreach % seq level
       TrainThreeModels(dt = restr.train.list[[n]][[m]],
                        category = category.norm.list[[m]],
                        seed = resample.seed,
@@ -148,7 +147,6 @@ restr.train.list$tdm$`0` <- NULL
 restr.train.list$tdm$`100` <- NULL
 
 # get training kappa stats and write to file
-message("gets here 1")
 train.kappa.df <- PredictWrapper(train.model.list = train.model.list,
                                  pred.list = restr.train.list,
                                  sample.df = sample.train.test,
@@ -160,7 +158,6 @@ write.table(train.kappa.df, file = train.kappa.file, sep = "\t",
 #### predictions - test data ---------------------------------------------------
 
 # get predictions on array test data as a data frame
-message("gets here 2")
 array.kappa.df <- PredictWrapper(train.model.list = train.model.list,
                                  pred.list = norm.test.list$array,
                                  sample.df = sample.train.test,
@@ -180,7 +177,6 @@ for(i in 1:length(train.model.list[[5]])){
 norm.test.list$seq$tdm$`100` <- NULL
 
 # get predictions on RNA-seq test data as a data frame
-message("gets here 3")
 seq.kappa.df <- PredictWrapper(train.model.list = train.model.list,
                                pred.list = norm.test.list$seq,
                                sample.df = sample.train.test,

--- a/2-train_test_category.R
+++ b/2-train_test_category.R
@@ -170,7 +170,7 @@ write.table(array.kappa.df, file = array.kappa.file, sep = "\t",
 # array data (100% array data) should be tested on the TDM transformed seq data
 for(i in 1:length(train.model.list[[5]])){
   train.model.list[[5]][[i]]$`0` <- train.model.list[["log"]][[i]]$`0`
-  train.model.list[[5]][[i]] <- train.model.list[[5]][[i]][c(10, 1:9)]
+  train.model.list[[5]][[i]] <- train.model.list[["tdm"]][[i]][c(10, 1:9)]
 }
 
 # get rid of 100 tdm list, it's NULL

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -342,7 +342,7 @@ SinglePlatformNormalizationWrapper <- function(dt, platform = "array",
       # by design, untransformed data should not be zero to one transformed,
       # so just add the data.table (dt) that contains RNA-seq data (RSEM)
       # to the list
-      norm.list[["un"]] <- data.matrix(dt)
+      norm.list[["un"]] <- dt
     }
   } else {
     stop("platform parameter should be set to 'array' or 'seq'")

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -326,7 +326,7 @@ SinglePlatformNormalizationWrapper <- function(dt, platform = "array",
     }
     # should untransformed (log2 scale, not zero_to_one) array data be added?
     if (add.untransformed){
-      norm.list[["un"]] <- LOGArrayOnly(dt, zto = FALSE)
+      norm.list[["un"]] <- LOGArrayOnly(dt, zero.to.one = FALSE)
     }
   } else if (platform == "seq") {
     norm.list[["log"]] <- LOGSeqOnly(dt, zto)

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -305,12 +305,14 @@ SinglePlatformNormalizationWrapper <- function(dt, platform = "array",
   #              if zero.to.one = TRUE zero to one transformed, data.tables
   #
 
+  ### Commented out to allow for log2-scaled array data to be added as
+  ### untransformed negative control at 0% RNA-seq
   # error-handling
-  if (platform == "array" & add.untransformed) {
-    warning("If add.transformed = TRUE, must be RNA-seq data (platform = seq).\n
-             Setting add.untransformed to FALSE...")
-    add.untransformed <- FALSE
-  }
+  #if (platform == "array" & add.untransformed) {
+  #  warning("If add.transformed = TRUE, must be RNA-seq data (platform = seq).\n
+  #           Setting add.untransformed to FALSE...")
+  #  add.untransformed <- FALSE
+  #}
 
   norm.list <- list()
   if (platform == "array") {
@@ -321,6 +323,10 @@ SinglePlatformNormalizationWrapper <- function(dt, platform = "array",
     # should quantile normalized data followed by z-transformation be added?
     if (add.qn.z) {
       norm.list[["qn-z"]] <- QNZSingleDT(norm.list$log, zto)
+    }
+    # should untransformed (log2 scale, not zero_to_one) array data be added?
+    if (add.untransformed){
+      norm.list[["un"]] <- LOGArrayOnly(dt, zto = FALSE)
     }
   } else if (platform == "seq") {
     norm.list[["log"]] <- LOGSeqOnly(dt, zto)

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -342,7 +342,7 @@ SinglePlatformNormalizationWrapper <- function(dt, platform = "array",
       # by design, untransformed data should not be zero to one transformed,
       # so just add the data.table (dt) that contains RNA-seq data (RSEM)
       # to the list
-      norm.list[["un"]] <- dt
+      norm.list[["un"]] <- data.matrix(dt)
     }
   } else {
     stop("platform parameter should be set to 'array' or 'seq'")

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -704,12 +704,14 @@ UnNoZTOProcessing <- function(array.dt = NULL, seq.dt = NULL) {
     stop("Cannot have array.dt and seq.dt both NULL in UnNoZTOProcessing()")
   }
   
+  # If the only input is seq data, there is nothing to be done -- just return it
   if (array.dt.null & !seq.dt.null) {
     
     return(seq.dt) # don't need to do anything to to seq.dt
     
-  } else {
+  } else { # if there is array data, we need to do something to it
     
+    # extract the gene vector and array column names
     gene_vector <- array.dt[,1]  
     array_column_names <- colnames(array.dt)
     
@@ -718,19 +720,21 @@ UnNoZTOProcessing <- function(array.dt = NULL, seq.dt = NULL) {
     
     array_matrix <- data.matrix(array.dt[, -1, with = F])
     
+    # if there is no seq data, set up the returned object with just array
     if (seq.dt.null) {
       
       un_datatable <- data.table(data.frame(gene_vector, array_matrix))
       colnames(un_datatable) <- array_column_names
       
-    } else {
+    } else { # if there is both seq and array data to combine
       
+      # extract seq column names, without the gene column
       seq_column_names <- colnames(seq.dt)[-1]
-      
+  
+      # combine gene, array, and seq data    
       un_datatable <- data.table(data.frame(gene_vector,
                                             array_matrix,
                                             seq.dt[ , -1, with = F]))
-      
       colnames(un_datatable) <- c(array_column_names, seq_column_names)
       
     }


### PR DESCRIPTION
Closes #85 

We want to add untransformed (UN) as negative control and quantile normalized then z-scored (QN-Z) data at early stage of data set creation. Later steps handle the presence of UN and QN-Z naturally, without fuss.

There were already options in place to add UN for RNA-seq and QN-Z for both RNA-seq and array. I modified some checks and options to allow UN 0% RNA-seq (100% array) to have just log array data.

In another place, we previously manually modified TDM data by referring to its numeric position within the list, which changes when adding UN and QN-Z. Now TDM data is referred to by name, not position.

I have tested the output of these changes with downstream analysis steps and all 👍 UN gives us a visual negative control for all experiments. We can choose to keep UN and QN-Z or filter out at any time.
