### PR TITLE
Envest/73 no silver standard pathway analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ normalized_data
 models
 results/reconstructed_data
 .Rproj.user
+RNAseq_titration_results.Rproj

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data
 normalized_data
 models
 results/reconstructed_data
+.Rproj.user

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -103,7 +103,7 @@ check_failure_to_converge <- function(plier_result) {
   # if the plier result contained an error message
   if ("message" %in% names(plier_result)) {
     # and if that error massage refers to convergence failure
-    if (str_detect(x$message, "system is computationally singular")) {
+    if (str_detect(plier_result$message, "system is computationally singular")) {
       NA # return NA
     } else { # PLIER failed for another reason and we need to know about that
       stop("PLIER run failed for reason other than system is computationally singular")

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -322,7 +322,7 @@ for (seed_index in 1:length(norm.train.files)) {
   # Check for failure to converge, and set to NA
   
   plier_results_list <- purrr::modify_depth(plier_results_list, 2,
-                                            check_plier_failure
+                                            check_plier_failure_to_converge
   )
   
   # Return pathway comparison for appropriate level of PLIER results list

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -96,14 +96,15 @@ convert_row_names <- function(expr, cancer_type) {
   )
 }
 
-#### Function to check if a PLIER model converged or not
+#### Failure of PLIER to converge may manifest in different error messages...
 
-check_failure_to_converge <- function(plier_result) {
+check_plier_failure_to_converge <- function(plier_result) {
 
   # if the plier result contained an error message
   if ("message" %in% names(plier_result)) {
-    # and if that error massage refers to convergence failure
-    if (str_detect(plier_result$message, "system is computationally singular")) {
+    # and if that error massage refers to convergence failure directly or indirectly
+    if (str_detect(plier_result$message, "system is computationally singular") | 
+        str_detect(plier_result$message, "subscript out of bounds")) {
       NA # return NA
     } else { # PLIER failed for another reason and we need to know about that
       stop("PLIER run failed for reason other than system is computationally singular")
@@ -312,7 +313,7 @@ for (seed_index in 1:length(norm.train.files)) {
   # Check for failure to converge, and set to NA
   
   plier_results_list <- purrr::modify_depth(plier_results_list, 2,
-                                            check_failure_to_converge
+                                            check_plier_failure
   )
   
   # Return pathway comparison for appropriate level of PLIER results list

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -109,7 +109,7 @@ check_failure_to_converge <- function(plier_result) {
       stop("PLIER run failed for reason other than system is computationally singular")
     }
   } else {
-    x # return the plier result as is
+    plier_result # return the plier result as is
   }
 }
 

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -290,7 +290,7 @@ for (seed_index in 1:length(norm.train.files)) {
                      scale = TRUE # PLIER z-scores input values by row
         )
       } else {
-        NULL # return NULL for empty result; purrr will ignore this list element
+        NA # NA for no data at this ps nm combination (0% and 100% TDM)
       }
     }
   }

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -38,6 +38,7 @@ message(paste("\nPLIER initial seed set to:", initial.seed))
 data.dir <- here::here("data")
 norm.data.dir <- here::here("normalized_data")
 res.dir <- here::here("results")
+plots.dir <- here::here("plots")
 
 # define input files
 norm.train.files <- file.path(
@@ -232,55 +233,86 @@ for (seed_index in 1:length(norm.train.files)) {
       )
     }
   )
-  
+
   #### main --------------------------------------------------------------------
   
+  # parallel backend
+  cl <- parallel::makeCluster(floor(detectCores()/2))
+  doParallel::registerDoParallel(cl)
+
   # create an output list
   plier_results_list <- list()
   
-  # parallel backend
-  cl <- parallel::makeCluster(detectCores() - 1)
-  doParallel::registerDoParallel(cl)
+  # at different titration levels (0-100% RNA-seq) and normalization methods
+  # generate the PLIER results for array alone, seq alone, and array + seq combo
   
-  # at each titration level (0-100% RNA-seq)
-  perc_seq <- as.character(seq(0, 100, 10))
-  norm_methods <- c("log", "npn", "qn", "qn-z", "tdm", "un", "z")
-  
+  perc_seq <- as.character(seq(0, 100, 50))
+  norm_methods_if_0_100 <- c("log")
+  norm_methods_else <- c("log", "npn", "qn", "qn-z", "tdm", "z",
+                         "array_only", "seq_only")
+
   plier_results_list <- foreach(
     ps = perc_seq,
     .packages = c("PLIER", "doParallel")
-  ) %dopar% {
+  ) %do% {
+    message(str_c("  PLIER at ", ps, "% RNA-seq"))
+
+    if (ps %in% c("0", "100")) { # no need to add array_only or seq_only
+
+      norm_methods <- norm_methods_if_0_100
+
+    } else {
+
+      norm_methods <- norm_methods_else
+
+      # get array and seq sample columns     
+      array_only_columns_tf <- names(norm.train.list[["0"]][["log"]]) %in%
+        names(norm.train.list[[ps]][["raw.array"]])
+
+      seq_only_columns_tf <- !array_only_columns_tf
+
+      # add array only and seq only data to each % RNA-seq
+      norm.train.list[[ps]][["array_only"]] <- norm.train.list[["0"]][["log"]][,array_only_columns_tf]
+      norm.train.list[[ps]][["seq_only"]] <- norm.train.list[["100"]][["log"]][,seq_only_columns_tf]
+
+    }
+
     foreach(
       nm = norm_methods,
+      .packages = c("PLIER", "doParallel"),
       .errorhandling = "pass" # let pass on inside loop
     ) %dopar% {
+
       if (nm %in% names(norm.train.list[[ps]])) {
-        
+
         # remove any rows with all the same value
         all.same.indx <- which(apply(
           norm.train.list[[ps]][[nm]], 1,
           check_all_same
         ))
+
         if (length(all.same.indx) > 0) {
           norm.train.list[[ps]][[nm]] <- norm.train.list[[ps]][[nm]][-all.same.indx, ]
         }
-        
+
         # get common genes
         common.genes <- PLIER::commonRows(
           all.paths,
           norm.train.list[[ps]][[nm]]
         )
-        
+
         # minimum k for PLIER = 2*num.pc
         set.k <- 2 * PLIER::num.pc(PLIER::rowNorm(norm.train.list[[ps]][[nm]][common.genes, ]))
-        
+
         # PLIER main function
         PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
                      all.paths[common.genes, ],
                      k = set.k,
                      scale = TRUE # PLIER z-scores input values by row
         )
+
       } else {
+
         NA # NA for no data at this ps nm combination (0% and 100% TDM)
       }
     }
@@ -292,27 +324,25 @@ for (seed_index in 1:length(norm.train.files)) {
   # renames list levels
   names(plier_results_list) <- perc_seq
   for (i in perc_seq) {
-    names(plier_results_list[[i]]) <- norm_methods
+    if (i %in% c("0", "100")) {
+      names(plier_results_list[[i]]) <- norm_methods_if_0_100
+    } else {
+      names(plier_results_list[[i]]) <- norm_methods_else
+    }
   }
   
-  # write test file
+  # Check for failure to converge, and set to NA
+  plier_results_list <- purrr::modify_depth(plier_results_list, 2,
+                                            check_plier_failure_to_converge
+  )
   
-  write_rds(x = plier_results_list,
-            path = str_c("plier.", seed_index, ".rds"))
+  # Return pathway comparison for appropriate level of PLIER results list
+  jaccard_list[[seed_index]] <- purrr::modify_depth(
+    plier_results_list, 2,
+    function(x) return_plier_jaccard_global(x, PLIER_pathways)
+  )
   
 }
-
-# Check for failure to converge, and set to NA
-
-plier_results_list <- purrr::modify_depth(plier_results_list, 2,
-                                          check_plier_failure_to_converge
-)
-
-# Return pathway comparison for appropriate level of PLIER results list
-jaccard_list[[seed_index]] <- purrr::modify_depth(
-  plier_results_list, 2,
-  function(x) return_plier_jaccard_global(x, PLIER_pathways)
-)
 
 if (length(jaccard_list) > 0) {
   
@@ -339,5 +369,34 @@ if (length(jaccard_list) > 0) {
     )
   )
   
-  # TODO PLOT THAT
+  # Plot results
+  
+  plot_filename = file.path(
+    plots.dir,
+    str_c(file_identifier, "_PLIER_jaccard.pdf")
+  )
+  
+  jaccard_df %>%
+    mutate(pseq = as.factor(pseq),
+           nmeth = str_to_upper(nmeth)) %>%
+    ggplot(aes(x = pseq,
+               y = jaccard)) +
+    geom_violin() +
+    stat_summary(fun = median, geom = "line", aes(group = "pseq"),
+                 position = position_dodge(0.6)) +
+    stat_summary(fun = median, geom = "point", aes(group = "pseq"),
+                 position = position_dodge(0.7), size = 1) +
+    expand_limits(y = 0) +
+    facet_wrap(~ nmeth,
+               nrow = 1) +
+    ggtitle(cancer_type) +
+    xlab("% RNA-seq samples") +
+    ylab("Proportion") +
+    theme_bw() +
+    theme(text = element_text(size = 18)) +
+    theme(axis.text.x = element_text(angle = 45, vjust = 0.5))
+  
+  ggsave(plot_filename,
+         plot = last_plot(),
+         height = 3.5, width = 15)
 }

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -304,14 +304,16 @@ for (seed_index in 1:length(norm.train.files)) {
     names(plier_results_list[[i]]) <- norm_methods
   }
   
+  # write test file
+  
+  write_rds(x = plier_results_list,
+            path = str_c("plier.", seed_index, ".rds"))
+  
   # Check for failure to converge, and set to NA
   
   plier_results_list <- purrr::modify_depth(plier_results_list, 2,
                                             check_failure_to_converge
   )
-  
-  #write_rds(x = plier_results_list,
-  #          path = str_c("plier.", seed_index, ".rds"))
   
   # Return pathway comparison for appropriate level of PLIER results list
   jaccard_list[[seed_index]] <- purrr::modify_depth(

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -251,10 +251,10 @@ for (seed_index in 1:length(norm.train.files)) {
   doParallel::registerDoParallel(cl)
   
   # at each titration level (0-100% RNA-seq)
-  #perc_seq <- as.character(seq(0, 100, 10))
-  #norm_methods <- c("log", "npn", "qn", "qn-z", "tdm", "un", "z")
-  perc_seq <- as.character(seq(40, 50, 10))
-  norm_methods <- c("un", "z")
+  perc_seq <- as.character(seq(0, 100, 10))
+  norm_methods <- c("log", "npn", "qn", "qn-z", "tdm", "un", "z")
+  #perc_seq <- as.character(seq(40, 50, 10))
+  #norm_methods <- c("un", "z")
   plier_results_list <- foreach(
     ps = perc_seq,
     .packages = c("PLIER", "doParallel")
@@ -310,8 +310,8 @@ for (seed_index in 1:length(norm.train.files)) {
                                             check_failure_to_converge
   )
   
-  write_rds(x = plier_results_list,
-            path = str_c("plier.", seed_index, ".rds"))
+  #write_rds(x = plier_results_list,
+  #          path = str_c("plier.", seed_index, ".rds"))
   
   # Return pathway comparison for appropriate level of PLIER results list
   jaccard_list[[seed_index]] <- purrr::modify_depth(

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -201,15 +201,18 @@ for (seed_index in 1:length(norm.train.files)) {
   doParallel::registerDoParallel(cl)
   
   # at each titration level (0-100% RNA-seq)
-  perc_seq <- as.character(seq(0, 100, 10))
+  #perc_seq <- as.character(seq(0, 100, 10))
   #norm_methods <- c("log", "npn", "qn", "qn-z", "tdm", "un", "z")
+  perc_seq <- as.character(seq(40, 50, 10))
   norm_methods <- c("un", "z")
   plier_results_list <- foreach(
     ps = perc_seq,
-    .packages = c("PLIER", "doParallel"),
-    .errorhandling = "pass"
+    .packages = c("PLIER", "doParallel")
   ) %dopar% {
-    foreach(nm = norm_methods) %dopar% {
+    foreach(
+      nm = norm_methods,
+      .errorhandling = "pass" # let pass on inside loop
+    ) %dopar% {
       if (nm %in% names(norm.train.list[[ps]])) {
         
         # remove any rows with all the same value
@@ -250,6 +253,8 @@ for (seed_index in 1:length(norm.train.files)) {
   for (i in perc_seq) {
     names(plier_results_list[[i]]) <- norm_methods
   }
+  
+  # TODO check for failure to converge, write message, set to NULL
   
   write_rds(x = plier_results_list,
             path = str_c("plier.", seed_index, ".rds"))

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -24,7 +24,10 @@ else
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
 fi
 
-# Run the unsupervised analyses
-Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
-Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
-Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+# Run the unsupervised analyses using subtype models
+if [ $predictor == "subtype" ]; then
+  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
+  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type
+fi


### PR DESCRIPTION
PLIER Part IV: A New Hope

This branch does two new things.

- Do not use a silver set for jaccard
  - Previously, we focused on a silver set comparison for the jaccard value (using the function `return_plier_jaccard_silver()`). The problem with that was how to define a silver set. So now we just compare significant pathways with the universe of potential pathways (new function `return_plier_jaccard_global()`).
  - We now report a proportion of pathways found significant, but it's also a Jaccard score (intersect/union when the union covers the whole space). I wanted to keep the idea of jaccard and column names consistent between the two functions in the off chance we do find a good way to define the silver standard.
  - The jaccard functions look to see if there is a "summary" in the PLIER list, which contains info on significant pathways. If not (as addressed below), the result is a row of NAs in the output.

- How to handle failed PLIER runs
  - This branch also responds to issues encountered with the addition of UNtransformed data to the data set.
  - In some cases, our PLIER models do not converge when untransformed data is used as input (even though PLIER does a z transform). A reason for this I believe that when log2 array data are combined with raw seq counts, the scales of the two data sources are very different, and this can lead to computationally singular matrices during processing.
  - When some of these tasks fail, we need the other tasks to be able to proceed. I used `.errorhandling = "pass"` on the inner `foreach()` loop. This returns the error message to the nested list so we can see what happened.
  - _According to people with opinions on the internet,_ such an error handling approach can be dangerous when the types of errors encountered may be wide ranging. In our case, I check for two specific error messages which we let go; the whole thing fails if the error message is anything but those two.
  - I have only encountered these errors with a few of the UNtransformed data sets, so the relative impact is minimal given that we have 10 replicates at each %RNA-seq.
  - The function `check_plier_failure_to_converge()` checks for those messages, returns NA if there was an allowed failure, and returns the PLIER object if everything is okay.

Thanks for your review -- next up is plotting the results :) 