### PR TITLE
Envest/89 allow zeros in na to zero

### DIFF
--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -1,4 +1,4 @@
-NAToZero <- function(dt, un=0) suppressWarnings(gdata::NAToUnknown(dt, un))
+NAToZero <- function(dt, un=0, force = TRUE) suppressWarnings(gdata::NAToUnknown(dt, un))
 
 #### single platform functions -------------------------------------------------
 LOGArrayOnly <- function(array.dt, zero.to.one = TRUE){

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -1,4 +1,4 @@
-NAToZero <- function(dt, un=0, force = TRUE) suppressWarnings(gdata::NAToUnknown(dt, un))
+NAToZero <- function(dt, un=0) suppressWarnings(gdata::NAToUnknown(dt, un, force = TRUE))
 
 #### single platform functions -------------------------------------------------
 LOGArrayOnly <- function(array.dt, zero.to.one = TRUE){


### PR DESCRIPTION
Closes #89 

See the issue for more explanation -- basically now that UN data gets added, there is an issue with pre-existing zeros and the function that converts `NAtoZero()`. We can let that function be more permissive (by letting zeros be zero) without losing anything. This wasn't identified in testing with GBM because GBM does not have any NA values starting out, but BRCA does. BRCA data, which had failed, now works. Thanks!