### PR TITLE
Envest/73 plier 06 raw vs combined

### DIFF
--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -260,7 +260,7 @@ for (seed_index in 1:length(norm.train.files)) {
     # get array and seq sample columns     
     array_only_columns_tf <- names(norm.train.list[["0"]][["log"]]) %in%
       names(norm.train.list[[ps]][["raw.array"]])
-    seq_only_columns_tf <- !array_only_columns_tf[-1]
+    seq_only_columns_tf <- !array_only_columns_tf
     
     # add array only and seq only data to each % RNA-seq
     norm.train.list[[ps]][["array_only"]] <- norm.train.list[["0"]][["log"]][,array_only_columns_tf]

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -220,8 +220,9 @@ for (seed_index in 1:length(norm.train.files)) {
   
   #### read in data ------------------------------------------------------------
   
+  message("here1")
   norm.train.list <- read_rds(norm.train.files[seed_index])
-  
+  message("here2")
   # convert gene names column to row names
   # if GBM, also convert from GENEID to SYMBOL
   norm.train.list <- purrr::modify_depth(
@@ -233,13 +234,13 @@ for (seed_index in 1:length(norm.train.files)) {
       )
     }
   )
-  
+  message("here3")
   #### main --------------------------------------------------------------------
   
   # parallel backend
   cl <- parallel::makeCluster(detectCores() - 1)
   doParallel::registerDoParallel(cl)
-  
+  message("here4")
   # create an output list
   plier_results_list <- list()
   
@@ -247,67 +248,72 @@ for (seed_index in 1:length(norm.train.files)) {
   # generate the PLIER results for array alone, seq alone, and array + seq combo
   
   perc_seq <- as.character(seq(0, 100, 50))
-  
+  message("here5")
   plier_results_list <- foreach(
     ps = perc_seq,
-    .packages = c("PLIER", "doParallel"),
+    .packages = c("PLIER", "doParallel")
   ) %do% {
-    
+    message("here6")
     message(str_c("  PLIER at ", ps, "% RNA-seq"))
-    
+    message("here7")
     if (ps %in% c("0", "100")) { # no need to add array_only or seq_only
-      
+      message("here8")
       norm_methods <- c("log", "npn", "qn", "qn-z", "tdm", "z")
-      
+      message("here9")
     } else {
-      
+      message("here10")
       norm_methods <- c("log", "npn", "qn", "qn-z", "tdm", "z",
                         "array_only", "seq_only")
-      
+      message("here11")
       # get array and seq sample columns     
       array_only_columns_tf <- names(norm.train.list[["0"]][["log"]]) %in%
         names(norm.train.list[[ps]][["raw.array"]])
+      message("here12")
       seq_only_columns_tf <- !array_only_columns_tf
+      message("here13")
       
       # add array only and seq only data to each % RNA-seq
       norm.train.list[[ps]][["array_only"]] <- norm.train.list[["0"]][["log"]][,array_only_columns_tf]
       norm.train.list[[ps]][["seq_only"]] <- norm.train.list[["100"]][["log"]][,seq_only_columns_tf]
-      
+      message("here14")
     }
-    
+    message("here15")
     foreach(
       nm = norm_methods,
       .packages = c("PLIER", "doParallel"),
       .errorhandling = "pass" # let pass on inside loop
     ) %dopar% {
-      
+      message("here16")
       if (nm %in% names(norm.train.list[[ps]])) {
-        
+        message("here17")
         # remove any rows with all the same value
         all.same.indx <- which(apply(
           norm.train.list[[ps]][[nm]], 1,
           check_all_same
         ))
+        message("here18")
         if (length(all.same.indx) > 0) {
           norm.train.list[[ps]][[nm]] <- norm.train.list[[ps]][[nm]][-all.same.indx, ]
         }
-        
+        message("here19")
         # get common genes
         common.genes <- PLIER::commonRows(
           all.paths,
           norm.train.list[[ps]][[nm]]
         )
-        
+        message("here20")
         # minimum k for PLIER = 2*num.pc
         set.k <- 2 * PLIER::num.pc(PLIER::rowNorm(norm.train.list[[ps]][[nm]][common.genes, ]))
-        
+        message("here21")
         # PLIER main function
         PLIER::PLIER(as.matrix(norm.train.list[[ps]][[nm]][common.genes, ]),
                      all.paths[common.genes, ],
                      k = set.k,
                      scale = TRUE # PLIER z-scores input values by row
         )
+        message("here22")
       } else {
+        message("here23")
         NA # NA for no data at this ps nm combination (0% and 100% TDM)
       }
     }

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -255,7 +255,7 @@ for (seed_index in 1:length(norm.train.files)) {
     
     message(str_c("  PLIER at ", ps, "% RNA-seq"))
     
-    if (perc_seq %in% c("0", "100")) { # no need to add array_only or seq_only
+    if (ps %in% c("0", "100")) { # no need to add array_only or seq_only
       
       norm_methods <- c("log", "npn", "qn", "qn-z", "tdm", "z")
       

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -330,19 +330,19 @@ for (seed_index in 1:length(norm.train.files)) {
       names(plier_results_list[[i]]) <- norm_methods_else  
     }
   }
+  
+  # Check for failure to converge, and set to NA
+  plier_results_list <- purrr::modify_depth(plier_results_list, 2,
+                                            check_plier_failure_to_converge
+  )
+  
+  # Return pathway comparison for appropriate level of PLIER results list
+  jaccard_list[[seed_index]] <- purrr::modify_depth(
+    plier_results_list, 2,
+    function(x) return_plier_jaccard_global(x, PLIER_pathways)
+  )
+  
 }
-
-# Check for failure to converge, and set to NA
-
-plier_results_list <- purrr::modify_depth(plier_results_list, 2,
-                                          check_plier_failure_to_converge
-)
-
-# Return pathway comparison for appropriate level of PLIER results list
-jaccard_list[[seed_index]] <- purrr::modify_depth(
-  plier_results_list, 2,
-  function(x) return_plier_jaccard_global(x, PLIER_pathways)
-)
 
 if (length(jaccard_list) > 0) {
   

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -237,7 +237,8 @@ for (seed_index in 1:length(norm.train.files)) {
   #### main --------------------------------------------------------------------
   
   # parallel backend
-  cl <- parallel::makeCluster(detectCores() - 1)
+  #cl <- parallel::makeCluster(detectCores() - 1)
+  cl <- parallel::makeCluster(floor(detectCores()/2))
   doParallel::registerDoParallel(cl)
 
   # create an output list
@@ -247,7 +248,7 @@ for (seed_index in 1:length(norm.train.files)) {
   # generate the PLIER results for array alone, seq alone, and array + seq combo
   
   perc_seq <- as.character(seq(0, 100, 50))
-  norm_methods_if_0_100 <- c("log", "npn", "qn", "qn-z", "tdm", "z")
+  norm_methods_if_0_100 <- c("log")
   norm_methods_else <- c("log", "npn", "qn", "qn-z", "tdm", "z",
                          "array_only", "seq_only")
 
@@ -327,7 +328,7 @@ for (seed_index in 1:length(norm.train.files)) {
     if (i %in% c("0", "100")) {
       names(plier_results_list[[i]]) <- norm_methods_if_0_100
     } else {
-      names(plier_results_list[[i]]) <- norm_methods_else  
+      names(plier_results_list[[i]]) <- norm_methods_else
     }
   }
   

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -237,7 +237,6 @@ for (seed_index in 1:length(norm.train.files)) {
   #### main --------------------------------------------------------------------
   
   # parallel backend
-  #cl <- parallel::makeCluster(detectCores() - 1)
   cl <- parallel::makeCluster(floor(detectCores()/2))
   doParallel::registerDoParallel(cl)
 

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -247,6 +247,9 @@ for (seed_index in 1:length(norm.train.files)) {
   # generate the PLIER results for array alone, seq alone, and array + seq combo
   
   perc_seq <- as.character(seq(0, 100, 50))
+  norm_methods_if_0_100 <- c("log", "npn", "qn", "qn-z", "tdm", "z")
+  norm_methods_else <- c("log", "npn", "qn", "qn-z", "tdm", "z",
+                         "array_only", "seq_only")
 
   plier_results_list <- foreach(
     ps = perc_seq,
@@ -256,12 +259,11 @@ for (seed_index in 1:length(norm.train.files)) {
 
     if (ps %in% c("0", "100")) { # no need to add array_only or seq_only
 
-      norm_methods <- c("log", "npn", "qn", "qn-z", "tdm", "z")
+      norm_methods <- norm_methods_if_0_100
 
     } else {
 
-      norm_methods <- c("log", "npn", "qn", "qn-z", "tdm", "z",
-                        "array_only", "seq_only")
+      norm_methods <- norm_methods_else
 
       # get array and seq sample columns     
       array_only_columns_tf <- names(norm.train.list[["0"]][["log"]]) %in%
@@ -322,7 +324,11 @@ for (seed_index in 1:length(norm.train.files)) {
   # renames list levels
   names(plier_results_list) <- perc_seq
   for (i in perc_seq) {
-    names(plier_results_list[[i]]) <- norm_methods
+    if (i %in% c("0", "100")) {
+      names(plier_results_list[[i]]) <- norm_methods_if_0_100
+    } else {
+      names(plier_results_list[[i]]) <- norm_methods_else  
+    }
   }
 }
 

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -260,7 +260,7 @@ for (seed_index in 1:length(norm.train.files)) {
     # get array and seq sample columns     
     array_only_columns_tf <- names(norm.train.list[["0"]][["log"]]) %in%
       names(norm.train.list[[ps]][["raw.array"]])
-    seq_only_columns_tf <- c(TRUE, !array_only_columns_tf[-1]) # -1 for gene column
+    seq_only_columns_tf <- !array_only_columns_tf[-1]
     
     # add array only and seq only data to each % RNA-seq
     norm.train.list[[ps]][["array_only"]] <- norm.train.list[["0"]][["log"]][,array_only_columns_tf]

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -250,6 +250,7 @@ for (seed_index in 1:length(norm.train.files)) {
   
   plier_results_list <- foreach(
     ps = perc_seq,
+    .packages = c("PLIER", "doParallel"),
   ) %do% {
     
     message(str_c("  PLIER at ", ps, "% RNA-seq"))

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -24,7 +24,10 @@ else
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
 fi
 
-# Run the unsupervised analyses
-Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
-Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
-Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+# Run the unsupervised analyses using subtype models
+if [ $predictor == "subtype" ]; then
+  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
+  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type
+fi


### PR DESCRIPTION
This PR reflect iteration around the question of how to show benefits of creating a larger data set for downstream analysis.

So now we have updated the approach to be:
- Run PLIER at 50/50% for each normalization method
- Run PLIER with array only (50% sample size) (LOG norm)
- Run PLIER with seq only (50% sample size) (LOG norm)

Other PLIER runs also included in this analysis are the full data at 0% and 100% RNA-seq (LOG norm) (not shown in current results, but data is available).

Another change to note is utilizing fewer cores than the `n-1` typically used in this project. This seems to have alleviated compute pressure when processing BRCA samples.

I expect one more PR in this stack to update the plotting to what is shown below, and to incorporate PLIER into the overall project flow!

![GBM_subtype_PLIER_jaccard](https://user-images.githubusercontent.com/10382980/150602234-0c2b0a24-f4e1-49ab-a3f2-d948acbf3ceb.png)

