### PR TITLE
Envest/qnz test data all percentages

### DIFF
--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -234,7 +234,7 @@ seq.qnz.list[["0"]] <- QNZSingleWithRef(ref.dt = norm.titrate.list$`0`$log,
 # data (this is LOG data, but only the array samples)
 seq.qnz.list[2:10] <-
   foreach(i = 2:10) %dopar% {
-    QNZingleWithRef(ref.dt = norm.titrate.list[[i]]$raw.array,
+    QNZSingleWithRef(ref.dt = norm.titrate.list[[i]]$raw.array,
                     targ.dt = seq.test)
   }
 names(seq.qnz.list)[2:10] <- names(norm.titrate.list)[2:10]

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -218,6 +218,37 @@ seq.qn.list[["100"]] <- QNSingleDT(seq.test)
 seq.test.norm.list[["qn"]] <- seq.qn.list
 rm(seq.qn.list)
 
+# start parallel backend
+cl <- parallel::makeCluster(detectCores() - 1)
+doParallel::registerDoParallel(cl)
+
+# QN-Z -- requires reference data
+# initialize list to hold QN data
+seq.qnz.list <- list()
+
+# for 0% seq - use 0% LOG array data
+seq.qnz.list[["0"]] <- QNZSingleWithRef(ref.dt = norm.titrate.list$`0`$log,
+                                        targ.dt = seq.test)
+
+# for 10-90% seq - use the "raw array" training data at each level of sequencing
+# data (this is LOG data, but only the array samples)
+seq.qnz.list[2:10] <-
+  foreach(i = 2:10) %dopar% {
+    QNZingleWithRef(ref.dt = norm.titrate.list[[i]]$raw.array,
+                    targ.dt = seq.test)
+  }
+names(seq.qnz.list)[2:10] <- names(norm.titrate.list)[2:10]
+
+# stop parallel back end
+parallel::stopCluster(cl)
+
+# QNZ 100% seq by itself (preProcessCore::normalize.quantiles)
+seq.qnz.list[["100"]] <- QNZSingleDT(seq.test)
+
+# add QNZ seq data to list of normalized test data
+seq.test.norm.list[["qn-z"]] <- seq.qnz.list
+rm(seq.qnz.list)
+
 # start parallel back end
 cl <- parallel::makeCluster(detectCores() - 1)
 doParallel::registerDoParallel(cl)
@@ -253,9 +284,6 @@ seq.test.norm.list[["z"]] <- ZScoreSingleDT(seq.test)
 
 # untransformed seq test data
 seq.test.norm.list[["un"]] <- seq.test
-
-# QN-Z seq test data
-seq.test.norm.list[["qn-z"]] <- QNZSingleDT(seq.test)
 
 # combine array and seq test data into a list
 test.norm.list <- list(array = array.test.norm.list,

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -254,8 +254,8 @@ QNZSingleWithRef <- function(ref.dt, targ.dt, zero.to.one = TRUE){
   #	  zero.to.one: logical - should the data be zero to one transformed?
   #
   # Returns:
-  #   qnz.targ: quantile normalized (quantiles from array data), z-scored,
-  #             zero to one transformed if zero.to.one = TRUE, data.table
+  #   qnz.dt: quantile normalized (quantiles from array data), z-scored,
+  #           zero to one transformed if zero.to.one = TRUE, data.table
   #
   require(data.table)
   # Error-handling

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -254,8 +254,8 @@ QNZSingleWithRef <- function(ref.dt, targ.dt, zero.to.one = TRUE){
   #	  zero.to.one: logical - should the data be zero to one transformed?
   #
   # Returns:
-  #   qn.targ: quantile normalized (quantiles from array data), zero to one
-  #            transformed if zero.to.one = TRUE, data.table
+  #   qnz.targ: quantile normalized (quantiles from array data), z-scored,
+  #             zero to one transformed if zero.to.one = TRUE, data.table
   #
   require(data.table)
   # Error-handling

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -240,6 +240,64 @@ QNSingleWithRef <- function(ref.dt, targ.dt, zero.to.one = TRUE){
   return(qn.targ)
 }
 
+QNZSingleWithRef <- function(ref.dt, targ.dt, zero.to.one = TRUE){
+  # This function takes array gene expression data.table as a reference and
+  # an RNA-seq expression data.table ('target') and returns the quantile
+  # normalized, z-scored, zero to one transformed (if zero.to.one = TRUE) RNA-seq
+  # expression data.table
+  #
+  # Args:
+  #   ref.dt: array data.table where the first column contains gene identifiers,
+  #           the columns are samples, rows are gene measurements
+  #   targ.dt: RNA-seq data.table where the first column contains gene
+  #            identifiers, the columns are samples, rows are gene measurements
+  #	  zero.to.one: logical - should the data be zero to one transformed?
+  #
+  # Returns:
+  #   qn.targ: quantile normalized (quantiles from array data), zero to one
+  #            transformed if zero.to.one = TRUE, data.table
+  #
+  require(data.table)
+  # Error-handling
+  ref.is.dt <- "data.table" %in% class(ref.dt)
+  targ.is.dt <- "data.table" %in% class(targ.dt)
+  any.not.dt <- !(any(c(ref.is.dt, targ.is.dt)))
+  if (any.not.dt) {
+    stop("ref.dt and targ.dt must both be data.tables")
+  }
+  if (!(all(ref.dt[[1]] %in% targ.dt[[1]]))) {
+    stop("Gene identifiers in data.tables must match")
+  }
+  ref.values <- data.frame(ref.dt[, 2:ncol(ref.dt), with = F])
+  target.values <- data.frame(targ.dt[, 2:ncol(targ.dt), with = F])
+  #  message("Quantile normalization...\n")
+  # get target object "reference" for the quantile normalization
+  qn.ref <-
+    preprocessCore::normalize.quantiles.determine.target(
+      data.matrix(ref.values),
+      target.length = nrow(ref.values))
+  
+  # quantile normalize the data, against reference (array) distribution, using
+  # replacement, not averaging
+  qn.targ <-
+    preprocessCore::normalize.quantiles.use.target(data.matrix(target.values),
+                                                   qn.ref,
+                                                   copy = F)
+  
+  # z-score the quantile normalized seq values
+  qnz.targ <- t(apply(qn.targ, 1, function(x) scale(as.numeric(x))))
+  
+  #  message("\tConcatenation...\n")
+  qnz.dt <- data.table(cbind(targ.dt[[1]], qnz.targ))
+  
+  colnames(qnz.dt) <- chartr(".", "-", colnames(qnz.dt))
+  #  message("\tZero to one transformation...\n")
+  if (zero.to.one) {
+    qnz.dt <- rescale_datatable(qnz.dt)
+  }
+  return(qnz.dt)
+}
+
 TDMSingleWithRef <- function(ref.dt, targ.dt, zero.to.one = TRUE){
   # This function takes array gene expression data.table as a reference and
   # an RNA-seq expression data.table ('target') and returns the TDM

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -293,7 +293,7 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
         trained.model <- model.list[[seq.lvl]]
         # if pred.data.list is a list (has different sequencing levels),
         # loop through the list -- this will be the case for RNA-seq hold out
-        # data for TDM and QN methods, as well as training data and
+        # data for TDM, QN, and QN-Z methods, as well as training data and
         # reconstructed data
         if (class(pred.data.list) == "list") {
           # for some cases of TDM normalized data, not every seq level is

--- a/visualize_expression.R
+++ b/visualize_expression.R
@@ -127,7 +127,7 @@ for (nm in norm_methods) {
   }
   
   # get vector of RNA-seq values
-  if (nm %in% c("qn", "tdm")) { # test data for normalization methods qn and tdm varies with RNA-seq % in training data
+  if (nm %in% c("qn", "qn-z", "tdm")) { # test data for normalization methods qn and tdm varies with RNA-seq % in training data
     for (pct_rna_seq in as.character(seq(0, 100, 10))) {
       if (!is.null(normalized_test_data$seq[[nm]][[pct_rna_seq]])) { # TDM is NULL at 100% RNA-seq
         seq_values <- as.vector(as.matrix(normalized_test_data$seq[[nm]][[pct_rna_seq]][gene_rows_included, -1]))
@@ -140,7 +140,7 @@ for (nm in norm_methods) {
                                 viz.dir, file_identifier)
       }
     }
-  } else { # test data for normalization methods other than qn and tdm do not vary with RNA-seq % in training data
+  } else { # test data for normalization methods that do not vary with RNA-seq % in training data
     seq_values <- as.vector(as.matrix(normalized_test_data$seq[[nm]][gene_rows_included, -1]))
     method_title <- str_to_upper(nm)
     plot_matched_expression(array_values, seq_values,


### PR DESCRIPTION
Previously, we added QN-Z as another normalization method, and it should be treated like QN for all intents and purposes. QN, QN-Z, and TDM normalization methods each depend on the values of the array distribution. For setting up training data, we have a mix of 0% - 100% RNA-seq titrated in, and the values of the X% RNA-seq are transformed to match the (100-X)% array values. That was all fine.

While looking over results from #76 I realized that when I added QN-Z to the test data, I had not accounted for the varying percentages of RNA-seq. Previously, I had used `QNZSingleDT()` from `util/normalization_functions.R`, which just QNs a single data set and then z-scores it. Then that was being evaluated against the various QN-Z training sets, which do vary by % RNA-seq. So, I needed to add a new function (`QNZSingleWithRef()`) to give QN-Z the same treatment as QN.

`QNZSingleWithRef()` is a mirror of the existing `QNSingleWithRef()` with the additional step of z-scoring by row. The updated `1-normalize_titrated_data.R` calls this QN-Z function when constructing the test data from 0% to 90% RNA-seq, just like for QN. 100% RNA-seq does not rely on array data.

This has been tested and all runs fine. The output test data has levels for 0-100% RNA-seq as expected. Thanks!