### PR TITLE
Envest/73 plier 07 run plier in bash script

### DIFF
--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -28,3 +28,4 @@ fi
 Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
 Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
 Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -24,8 +24,10 @@ else
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
 fi
 
-# Run the unsupervised analyses
-Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
-Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
-Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
-Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type
+# Run the unsupervised analyses using subtype models
+if [ $predictor == "subtype" ]; then
+  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
+  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type
+fi


### PR DESCRIPTION
Closes #73

This PR adds `7-extract_plier_pathways.R` to the machine learning script `run_machine_learning_experiments.sh`. As discussed previously, we want to keep the unsupervised analyses simpler by only including subtype model, not gene mutation prediction models.

This should be the final installment in the stack adding PLIER to the project. Thanks!