### PR TITLE
Ensure the correct column names are added to QN-Z in QNZSingleWithRef

### DIFF
--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -290,7 +290,7 @@ QNZSingleWithRef <- function(ref.dt, targ.dt, zero.to.one = TRUE){
   #  message("\tConcatenation...\n")
   qnz.dt <- data.table(cbind(targ.dt[[1]], qnz.targ))
   
-  colnames(qnz.dt) <- chartr(".", "-", colnames(qnz.dt))
+  colnames(qnz.dt) <- chartr(".", "-", colnames(targ.dt))
   #  message("\tZero to one transformation...\n")
   if (zero.to.one) {
     qnz.dt <- rescale_datatable(qnz.dt)


### PR DESCRIPTION
This PR makes sure that QN-Z data generated by the recent function `QNZSingleWithRef()` has column names, which are necessary for sample selection. Thanks!