### PR TITLE
Envest/limit n cores

### DIFF
--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -21,7 +21,10 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)")
+                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)"),
+  optparse::make_option("--ncores",
+                        default = NA_integer_,
+                        help = "Set the number of cores to use")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -39,6 +42,9 @@ null_model <- opt$null_model
 file_identifier <- ifelse(null_model,
                           str_c(cancer_type, predictor, "null", sep = "_"),
                           str_c(cancer_type, predictor, sep = "_"))
+ncores <- min(parallel::detectCores() - 1,
+              opt$ncores,
+              na.rm = TRUE)
 
 # set seed
 filename.seed <- as.integer(opt$seed1)
@@ -137,8 +143,7 @@ norm.titrate.list[["0"]] <-
                                      add.qn.z = TRUE)
 
 # parallel backend
-#cl <- parallel::makeCluster(detectCores() - 1)
-cl <- parallel::makeCluster(7)
+cl <- parallel::makeCluster(ncores)
 doParallel::registerDoParallel(cl)
 
 # 'mixed' both platform normalization
@@ -189,8 +194,7 @@ seq.test.norm.list[["log"]] <- LOGSeqOnly(seq.test)
 seq.test.norm.list[["npn"]] <- NPNSingleDT(seq.test)
 
 # start parallel backend
-#cl <- parallel::makeCluster(detectCores() - 1)
-cl <- parallel::makeCluster(7)
+cl <- parallel::makeCluster(ncores)
 doParallel::registerDoParallel(cl)
 
 # QN -- requires reference data
@@ -221,8 +225,7 @@ seq.test.norm.list[["qn"]] <- seq.qn.list
 rm(seq.qn.list)
 
 # start parallel backend
-#cl <- parallel::makeCluster(detectCores() - 1)
-cl <- parallel::makeCluster(7)
+cl <- parallel::makeCluster(ncores)
 doParallel::registerDoParallel(cl)
 
 # QN-Z -- requires reference data
@@ -253,8 +256,7 @@ seq.test.norm.list[["qn-z"]] <- seq.qnz.list
 rm(seq.qnz.list)
 
 # start parallel back end
-#cl <- parallel::makeCluster(detectCores() - 1)
-cl <- parallel::makeCluster(7)
+cl <- parallel::makeCluster(ncores)
 doParallel::registerDoParallel(cl)
 
 # TDM normalization -- requires references

--- a/1-normalize_titrated_data.R
+++ b/1-normalize_titrated_data.R
@@ -137,7 +137,8 @@ norm.titrate.list[["0"]] <-
                                      add.qn.z = TRUE)
 
 # parallel backend
-cl <- parallel::makeCluster(detectCores() - 1)
+#cl <- parallel::makeCluster(detectCores() - 1)
+cl <- parallel::makeCluster(7)
 doParallel::registerDoParallel(cl)
 
 # 'mixed' both platform normalization
@@ -188,7 +189,8 @@ seq.test.norm.list[["log"]] <- LOGSeqOnly(seq.test)
 seq.test.norm.list[["npn"]] <- NPNSingleDT(seq.test)
 
 # start parallel backend
-cl <- parallel::makeCluster(detectCores() - 1)
+#cl <- parallel::makeCluster(detectCores() - 1)
+cl <- parallel::makeCluster(7)
 doParallel::registerDoParallel(cl)
 
 # QN -- requires reference data
@@ -219,7 +221,8 @@ seq.test.norm.list[["qn"]] <- seq.qn.list
 rm(seq.qn.list)
 
 # start parallel backend
-cl <- parallel::makeCluster(detectCores() - 1)
+#cl <- parallel::makeCluster(detectCores() - 1)
+cl <- parallel::makeCluster(7)
 doParallel::registerDoParallel(cl)
 
 # QN-Z -- requires reference data
@@ -250,7 +253,8 @@ seq.test.norm.list[["qn-z"]] <- seq.qnz.list
 rm(seq.qnz.list)
 
 # start parallel back end
-cl <- parallel::makeCluster(detectCores() - 1)
+#cl <- parallel::makeCluster(detectCores() - 1)
+cl <- parallel::makeCluster(7)
 doParallel::registerDoParallel(cl)
 
 # TDM normalization -- requires references

--- a/2-train_test_category.R
+++ b/2-train_test_category.R
@@ -104,7 +104,8 @@ set.seed(folds.seed)
 folds.list <- lapply(category.norm.list, function(x) createFolds(x, k = 5))
 
 # parallel backend
-cl <- makeCluster(detectCores()-1)
+#cl <- makeCluster(detectCores()-1)
+cl <- parallel::makeCluster(7)
 registerDoParallel(cl)
 
 resample.seed <- sample(1:10000, 1)

--- a/2-train_test_category.R
+++ b/2-train_test_category.R
@@ -21,7 +21,10 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)")
+                        help = "Refer to models with permuted dependent variable (within subtype if predictor is a gene)"),
+  optparse::make_option("--ncores",
+                        default = NA_integer_,
+                        help = "Set the number of cores to use")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -39,6 +42,9 @@ null_model <- opt$null_model
 file_identifier <- ifelse(null_model,
                           str_c(cancer_type, predictor, "null", sep = "_"),
                           str_c(cancer_type, predictor, sep = "_"))
+ncores <- min(parallel::detectCores() - 1,
+              opt$ncores,
+              na.rm = TRUE)
 
 # set seed
 filename.seed <- opt$seed1
@@ -104,8 +110,7 @@ set.seed(folds.seed)
 folds.list <- lapply(category.norm.list, function(x) createFolds(x, k = 5))
 
 # parallel backend
-#cl <- makeCluster(detectCores()-1)
-cl <- parallel::makeCluster(7)
+cl <- parallel::makeCluster(ncores)
 registerDoParallel(cl)
 
 resample.seed <- sample(1:10000, 1)

--- a/3A-small_n_differential_expression.R
+++ b/3A-small_n_differential_expression.R
@@ -3,7 +3,7 @@
 # (quantile normalization or z-transformation) perform wrt differential
 # expression when there are a small number of samples on each platform
 #
-# USAGE: Rscript 3A-small_n_differential_expression.R --cancer_type --subtype_vs_subtype
+# USAGE: Rscript 3A-small_n_differential_expression.R --cancer_type --subtype_vs_subtype --ncores
 
 option_list <- list(
   optparse::make_option("--cancer_type",
@@ -14,7 +14,10 @@ option_list <- list(
                         help = "Subtypes used in head-to-head comparison (comma-separated without space e.g. Type1,Type2)"),
   optparse::make_option("--seed",
                         default = 3255,
-                        help = "Random seed")
+                        help = "Random seed"),
+  optparse::make_option("--ncores",
+                        default = NA_integer_,
+                        help = "Set the number of cores to use")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -32,6 +35,9 @@ cancer_type <- opt$cancer_type
 subtype_vs_subtype <- opt$subtype_vs_subtype
 two_subtypes <- as.vector(stringr::str_split(subtype_vs_subtype, pattern = ",", simplify = TRUE))
 file_identifier <- str_c(cancer_type, "subtype", sep = "_") # we are only working with subtype models here
+ncores <- min(parallel::detectCores() - 1,
+              opt$ncores,
+              na.rm = TRUE)
 
 # set seed
 initial.seed <- opt$seed
@@ -114,7 +120,7 @@ stats.df.list <- list()
 
 # Do this at 0-100% RNA-seq titration levels
 # parallel backend
-cl <- parallel::makeCluster(detectCores() - 1)
+cl <- parallel::makeCluster(ncores)
 doParallel::registerDoParallel(cl)
 
 # at each titration level (0-100% RNA-seq)

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -3,7 +3,7 @@
 # in our data, and quantify the rate of return for significant PLIER pathways
 # for data coming from different normalization methods and titration levels.
 #
-# USAGE: Rscript 7-extract_plier_pathways.R --cancer_type --seed
+# USAGE: Rscript 7-extract_plier_pathways.R --cancer_type --seed --ncores
 
 option_list <- list(
   optparse::make_option("--cancer_type",
@@ -13,6 +13,10 @@ option_list <- list(
   optparse::make_option("--seed",
                         default = 8934,
                         help = "Random seed"
+  ),
+  optparse::make_option("--ncores",
+                        default = NA_integer_,
+                        help = "Set the number of cores to use"
   )
 )
 
@@ -28,6 +32,9 @@ source(here::here("util", "color_blind_friendly_palette.R"))
 # set options
 cancer_type <- opt$cancer_type
 file_identifier <- str_c(cancer_type, "subtype", sep = "_") # assuming subtype
+ncores <- min(parallel::detectCores() - 1,
+              opt$ncores,
+              na.rm = TRUE)
 
 # set seed
 initial.seed <- opt$seed
@@ -238,7 +245,7 @@ for (seed_index in 1:length(norm.train.files)) {
   #### main --------------------------------------------------------------------
   
   # parallel backend
-  cl <- parallel::makeCluster(floor(detectCores()/2))
+  cl <- parallel::makeCluster(ncores)
   doParallel::registerDoParallel(cl)
 
   # create an output list

--- a/run_differential_expression_experiments.sh
+++ b/run_differential_expression_experiments.sh
@@ -11,6 +11,7 @@ cancer_type=$1
 subtype_vs_others=$2
 subtype_vs_subtype=$3
 subtype_vs_subtype_small=$4
+ncores=$5
 
 if [ $cancer_type != "BRCA" ] && [ $cancer_type != "GBM" ]; then
   echo Cancer type must be BRCA or GBM in run_differential_expression_experiments.sh [cancer_type]
@@ -18,6 +19,6 @@ if [ $cancer_type != "BRCA" ] && [ $cancer_type != "GBM" ]; then
 fi
 
 # Run differential expression scripts
-Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type --subtype_vs_others $subtype_vs_others --subtype_vs_subtype $subtype_vs_subtype
+Rscript 1A-detect_differentially_expressed_genes.R --cancer_type $cancer_type --subtype_vs_others $subtype_vs_others --subtype_vs_subtype $subtype_vs_subtype --ncores $ncores
 Rscript 2A-plot_DE_results.R --cancer_type $cancer_type --subtype_vs_others $subtype_vs_others --subtype_vs_subtype $subtype_vs_subtype
-Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --subtype_vs_subtype $subtype_vs_subtype_small
+Rscript 3A-small_n_differential_expression.R --cancer_type $cancer_type --subtype_vs_subtype $subtype_vs_subtype_small --ncores $ncores

--- a/run_experiments.R
+++ b/run_experiments.R
@@ -2,7 +2,7 @@
 # The purpose of this script is to run the BRCA subtype classifier pipeline
 # for RNA-seq 'titration.'
 # It should be run from the command line.
-# USAGE: Rscript run_experiments.R --cancer_type [BRCA|GBM] --predictor [subtype|TP53|PIK3CA] --seed integer --null_model
+# USAGE: Rscript run_experiments.R --cancer_type [BRCA|GBM] --predictor [subtype|TP53|PIK3CA] --seed integer --null_model --ncores
 # It also may be run through the classifier_repeat_wrapper.R
 
 option_list <- list(
@@ -18,7 +18,10 @@ option_list <- list(
   optparse::make_option("--null_model",
                         action = "store_true",
                         default = FALSE,
-                        help = "Permute dependent variable (within subtype if predictor is a gene)")
+                        help = "Permute dependent variable (within subtype if predictor is a gene)"),
+  optparse::make_option("--ncores",
+                        default = NA_integer_,
+                        help = "Set the number of cores to use")
 )
 
 opt <- optparse::parse_args(optparse::OptionParser(option_list=option_list))
@@ -29,6 +32,9 @@ check_options(opt)
 cancer_type <- opt$cancer_type
 predictor <- opt$predictor
 null_model <- opt$null_model
+ncores <- min(parallel::detectCores() - 1,
+              opt$ncores,
+              na.rm = TRUE)
 
 # set seed
 initial.seed <- opt$seed
@@ -57,7 +63,8 @@ system(paste("Rscript 1-normalize_titrated_data.R",
              "--seed2", seeds[2],
              ifelse(null_model,
                     "--null_model",
-                    "")))
+                    ""),
+             "--ncores", ncores))
 
 message("\nTraining and testing models...")
 system(paste("Rscript 2-train_test_category.R",
@@ -67,4 +74,5 @@ system(paste("Rscript 2-train_test_category.R",
              "--seed3", seeds[3],
              ifelse(null_model,
                     "--null_model",
-                    "")))
+                    ""),
+             "--ncores", ncores))

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # cancer type (either BRCA or GBM)
 cancer_type=$1
 predictor=$2
+ncores=$3
 
 if [ $cancer_type != "BRCA" ] && [ $cancer_type != "GBM" ]; then
   echo Cancer type must be BRCA or GBM in run_machine_learning_experiments.sh [cancer_type] [predictor]
@@ -18,10 +19,10 @@ fi
 # Run ten repeats of the supervised analysis
 # if the predictor is a gene, also generate null models
 if [ $predictor == "TP53" ] || [ $predictor == "PIK3CA" ]; then
-  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
-  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model --ncores $ncores
 else
-  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
 fi
 
 # Run the unsupervised analyses using subtype models
@@ -29,5 +30,5 @@ if [ $predictor == "subtype" ]; then
   Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
   Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
   Rscript 6-plot_recon_error_kappa.R --cancer_type $cancer_type --predictor $predictor
-#  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type
+#  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores
 fi

--- a/util/option_functions.R
+++ b/util/option_functions.R
@@ -57,9 +57,9 @@ check_options <- function(opt) {
                                               "does not exist.")
       }
     } else if (option == "ncores") {
-      if (!is.integer(opt[[option]])) {
+      if (!is.integer(opt[[option]]) | opt[[option]] < 1) {
         my_errors[[option]] <- stringr::str_c("\nNumber of cores given for --", option,
-                                              " must be an integer.")
+                                              " must be a positive integer.")
       }
     }
   }

--- a/util/option_functions.R
+++ b/util/option_functions.R
@@ -56,6 +56,11 @@ check_options <- function(opt) {
                                               " (", dirname(opt[[option]]), ") ",
                                               "does not exist.")
       }
+    } else if (option == "ncores") {
+      if (!is.integer(opt[[option]])) {
+        my_errors[[option]] <- stringr::str_c("\nNumber of cores given for --", option,
+                                              " must be an integer.")
+      }
     }
   }
 


### PR DESCRIPTION
We want to give users the option to set the number of cores to something other than `n-1` available cores.

- So several places we add the option to set `ncores`:
```r
optparse::make_option("--ncores",
                        default = NA_integer_,
                        help = "Set the number of cores to use")
```
- And check that it is a positive integer in `util/option_functions.R`
```r
else if (option == "ncores") {
      if (!is.integer(opt[[option]]) | opt[[option]] < 1) {
        my_errors[[option]] <- stringr::str_c("\nNumber of cores given for --", option,
                                              " must be a positive integer.")
      }
```
- Set the number of cores to be the minimum of `n-1` and the given number:
```r
ncores <- min(parallel::detectCores() - 1,
              opt$ncores,
              na.rm = TRUE)
```
- And use the `ncores` variable to create clusters
```r
cl <- parallel::makeCluster(ncores)
```

- Users may specify `ncores` from the two `.sh` scripts `run_machine_learning_experiments.sh` and `run_differential_expression_experiments.sh`

For our data, I found that 7 cores worked well combined with 128 GiB memory. Thanks!