### PR TITLE
Envest/ungroup and write tsv fixes

### DIFF
--- a/3-combine_category_kappa.R
+++ b/3-combine_category_kappa.R
@@ -157,8 +157,8 @@ summary.df <- test.df %>%
   dplyr::group_by(Classifier, Normalization, Platform, Perc.Seq) %>%
   dplyr::summarise(Median = median(Kappa),
                    Mean = mean(Kappa),
-                   SD = sd(Kappa)) %>%
-  dplyr::ungroup()
+                   SD = sd(Kappa),
+                   .groups = "drop")
 
 readr::write_tsv(summary.df,
                  summary.df.filename) # delta or not delta in file name

--- a/6-save_recon_error_kappa_data.R
+++ b/6-save_recon_error_kappa_data.R
@@ -100,8 +100,8 @@ kappa.summary.df <-
   dplyr::group_by(Classifier, Normalization, Platform, Perc.seq) %>%
   dplyr::summarise(Median = median(Kappa),
                    Mean = mean(Kappa),
-                   SD = sd(Kappa)) %>%
-  dplyr::ungroup()
+                   SD = sd(Kappa),
+                   .groups = "drop")
 readr::write_tsv(kappa.summary.df,
                  file.path(rcn.res.dir,
                            paste0(file_identifier,
@@ -138,10 +138,9 @@ error.master.df$comp.method <- as.factor(error.master.df$comp.method)
 
 # take the average of each genes error across replicates
 error.mean.df <- error.master.df %>%
-  dplyr::group_by(gene, perc.seq, norm.method, comp.method,
-                  platform) %>%
-  dplyr::summarise(mean_mase = mean(MASE)) %>%
-  dplyr::ungroup()
+  dplyr::group_by(gene, perc.seq, norm.method, comp.method, platform) %>%
+  dplyr::summarise(mean_mase = mean(MASE),
+                   .groups = "drop")
 rm(error.master.df)
 colnames(error.mean.df) <- c("Gene", "Perc.seq", "Normalization",
                              "Method", "Platform", "Mean_Value")

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -375,9 +375,8 @@ if (length(jaccard_list) > 0) {
       "seed_index" = "L1"
     )
   
-  readr::write_tsv(
-    x = jaccard_df,
-    path = plot_data_filename
+  readr::write_tsv(jaccard_df,
+                   plot_data_filename
   )
   
 }

--- a/combine_clinical_data.R
+++ b/combine_clinical_data.R
@@ -60,4 +60,4 @@ combined_df <- clinical_df %>%
 ################################################################################
 
 write_tsv(combined_df,
-          file = combined_output_filepath)
+          combined_output_filepath)

--- a/combine_clinical_data.R
+++ b/combine_clinical_data.R
@@ -60,4 +60,4 @@ combined_df <- clinical_df %>%
 ################################################################################
 
 write_tsv(combined_df,
-          path = combined_output_filepath)
+          file = combined_output_filepath)

--- a/plots/scripts/2A-plot_small_n_differential_expression.R
+++ b/plots/scripts/2A-plot_small_n_differential_expression.R
@@ -133,7 +133,7 @@ plot_small_n <- function(subtypes){
          y = ifelse(using_single_measure,
                     unique(stats_df$measure),
                     "Measure of Similarity"),
-         title = paste(cancer_type, subtypes_nice, "FDR < 10%")) +
+         title = str_c("Small n Experiment: ", paste(cancer_type, subtypes_nice, "FDR < 10%"))) +
     scale_colour_manual(values = cbPalette[c(2, 3)])
   
   if (using_single_measure) {

--- a/plots/scripts/3-plot_category_kappa.R
+++ b/plots/scripts/3-plot_category_kappa.R
@@ -98,5 +98,5 @@ plot_obj <- ggplot(plot_df,
 
 ggsave(output_filename,
        plot = plot_obj,
-       height = 5,
-       width = 7.5)
+       height = 4,
+       width = 7.25)

--- a/plots/scripts/6-plot_recon_error.R
+++ b/plots/scripts/6-plot_recon_error.R
@@ -87,5 +87,5 @@ plot_obj <- ggplot(plot_df,
 
 ggsave(output_filename,
        plot = plot_obj,
-       height = 5,
-       width = 7.5)
+       height = 4,
+       width = 7.25)

--- a/plots/scripts/6-plot_recon_kappa.R
+++ b/plots/scripts/6-plot_recon_kappa.R
@@ -85,5 +85,5 @@ plot_obj <- ggplot(plot_df,
 
 ggsave(output_filename,
        plot = plot_obj,
-       height = 5,
-       width = 7.5)
+       height = 4,
+       width = 7.25)

--- a/plots/scripts/recon_kappa_difference.R
+++ b/plots/scripts/recon_kappa_difference.R
@@ -56,15 +56,15 @@ with_df <- read_tsv(with_recon_input_filename,
 
 without_summary_df <- without_df %>%
   group_by(Perc.Seq, Classifier, Normalization, Platform) %>%
-  summarize(median_without = median(Kappa)) %>%
-  ungroup()
+  summarize(median_without = median(Kappa),
+            .groups = "drop")
 
 with_summary_df <- with_df %>%
   filter(Reconstruction == "PCA",
          Measure == "kappa") %>%
   group_by(Perc.Seq, Classifier, Normalization, Platform) %>%
-  summarize(median_with = median(Kappa)) %>%
-  ungroup()
+  summarize(median_with = median(Kappa),
+            .groups = "drop")
 
 # combined data frames and calculate difference in median kappas
 

--- a/prepare_GBM_data.R
+++ b/prepare_GBM_data.R
@@ -213,12 +213,12 @@ missing_clinical <- gbm_subtypes %>%
 
 write_tsv(gbm_array_expression_renamed %>%
             select(-all_of(missing_clinical)),
-          file = gbm_array_output_filepath)
+          gbm_array_output_filepath)
 
 write_tsv(gbm_seq_expression_renamed %>%
             select(-all_of(missing_clinical)),
-          file = gbm_seq_output_filepath)
+          gbm_seq_output_filepath)
 
 write_tsv(gbm_subtypes %>%
             filter(!is.na(subtype)),
-          file = clinical_tsv_output_filepath)
+          clinical_tsv_output_filepath)

--- a/prepare_GBM_data.R
+++ b/prepare_GBM_data.R
@@ -124,8 +124,8 @@ gbm_seq_tumor_samples <- tibble(tcga_id_raw = tcga_seq_expression_column_names[-
   filter(sample == "01") %>% # require sample to be primary solid tumor
   filter(tcga_id %in% array_accession_tcga_id_keep$tcga_id) %>% # keep array GBMs
   group_by(tcga_patient, tcga_id) %>%
-  summarize(tcga_id_raw = sort(tcga_id_raw)[1]) %>% # keep one raw ID per person
-  ungroup()
+  summarize(tcga_id_raw = sort(tcga_id_raw)[1],
+            .groups = "drop") # keep one raw ID per person
 
 # now read in GBM subset of entire TCGA seq expression file
 # this is faster and uses less memory than reading in entire file and then subsetting

--- a/prepare_GBM_data.R
+++ b/prepare_GBM_data.R
@@ -123,9 +123,10 @@ gbm_seq_tumor_samples <- tibble(tcga_id_raw = tcga_seq_expression_column_names[-
          sample = str_sub(tcga_id_raw, 14, 15)) %>% # and sample is ZZ
   filter(sample == "01") %>% # require sample to be primary solid tumor
   filter(tcga_id %in% array_accession_tcga_id_keep$tcga_id) %>% # keep array GBMs
-  group_by(tcga_patient, tcga_id) %>%
-  summarize(tcga_id_raw = sort(tcga_id_raw)[1],
-            .groups = "drop") # keep one raw ID per person
+  group_by(tcga_patient) %>%
+  summarize(tcga_id_raw = sort(tcga_id_raw)[1], # keep one raw ID per person
+            tcga_id = str_sub(tcga_id_raw, 1, 15)) %>%
+  ungroup()
 
 # now read in GBM subset of entire TCGA seq expression file
 # this is faster and uses less memory than reading in entire file and then subsetting

--- a/prepare_GBM_data.R
+++ b/prepare_GBM_data.R
@@ -92,7 +92,8 @@ all_array_tumor_samples <- tibble(accession = names(metadata_json$samples)) %>%
 # keep one (first) accession per TCGA ID
 array_accession_tcga_id_keep <- all_array_tumor_samples %>%
   group_by(tcga_id) %>%
-  summarize(accession = sort(accession)[1])
+  summarize(accession = sort(accession)[1]) %>%
+  ungroup()
 accession_colnames_keep <- colnames(gbm_array_expression)[-1][colnames(gbm_array_expression)[-1] %in% array_accession_tcga_id_keep$accession]
 
 # select columns to keep and rename with TCGA IDs
@@ -123,7 +124,8 @@ gbm_seq_tumor_samples <- tibble(tcga_id_raw = tcga_seq_expression_column_names[-
   filter(sample == "01") %>% # require sample to be primary solid tumor
   filter(tcga_id %in% array_accession_tcga_id_keep$tcga_id) %>% # keep array GBMs
   group_by(tcga_patient, tcga_id) %>%
-  summarize(tcga_id_raw = sort(tcga_id_raw)[1]) # keep one raw ID per person
+  summarize(tcga_id_raw = sort(tcga_id_raw)[1]) %>% # keep one raw ID per person
+  ungroup()
 
 # now read in GBM subset of entire TCGA seq expression file
 # this is faster and uses less memory than reading in entire file and then subsetting
@@ -211,12 +213,12 @@ missing_clinical <- gbm_subtypes %>%
 
 write_tsv(gbm_array_expression_renamed %>%
             select(-all_of(missing_clinical)),
-          path = gbm_array_output_filepath)
+          file = gbm_array_output_filepath)
 
 write_tsv(gbm_seq_expression_renamed %>%
             select(-all_of(missing_clinical)),
-          path = gbm_seq_output_filepath)
+          file = gbm_seq_output_filepath)
 
 write_tsv(gbm_subtypes %>%
             filter(!is.na(subtype)),
-          path = clinical_tsv_output_filepath)
+          file = clinical_tsv_output_filepath)

--- a/run_all_analyses_and_plots.sh
+++ b/run_all_analyses_and_plots.sh
@@ -68,7 +68,7 @@ Rscript plots/scripts/1A-plot_DEGs.R \
   --subtype_vs_others Basal \
   --proportion_output_directory plots/supplementary \
   --overlap_output_directory plots/supplementary \
-  --overlap_measure Jaccard
+  --overlap_measure Jaccard,Spearman
   
 # bar plot showing proportion of genes differentially expressed (Her2 vs. LumA)
 # line plot showing overlap with silver standard DEGs (Her2 vs. LumA)
@@ -77,7 +77,7 @@ Rscript plots/scripts/1A-plot_DEGs.R \
   --subtype_vs_subtype Her2,LumA \
   --proportion_output_directory plots/supplementary \
   --overlap_output_directory plots/main \
-  --overlap_measure Jaccard
+  --overlap_measure Jaccard,Spearman
 
 # line plot showing overlap with silver standard DEGs (Her2 vs. LumA) across small n values
 Rscript plots/scripts/2A-plot_small_n_differential_expression.R \
@@ -110,6 +110,7 @@ Rscript plots/scripts/0-plot_predictor_category_distributions.R \
 Rscript plots/scripts/3-plot_category_kappa.R \
   --cancer_type BRCA \
   --predictor TP53 \
+  --null_model \
   --output_directory plots/supplementary
 
 # ------------------------------------------------------------------------------
@@ -136,6 +137,7 @@ Rscript plots/scripts/0-plot_predictor_category_distributions.R \
 Rscript plots/scripts/3-plot_category_kappa.R \
   --cancer_type BRCA \
   --predictor PIK3CA \
+  --null_model \
   --output_directory plots/supplementary
 
 # ------------------------------------------------------------------------------
@@ -201,7 +203,7 @@ Rscript plots/scripts/1A-plot_DEGs.R \
   --subtype_vs_subtype Classical,Mesenchymal \
   --proportion_output_directory plots/supplementary \
   --overlap_output_directory plots/supplementary \
-  --overlap_measure Jaccard
+  --overlap_measure Jaccard,Spearman
 
 # line plot showing overlap with silver standard DEGs (Classical vs. Mesenchymal) across small n values
 Rscript plots/scripts/2A-plot_small_n_differential_expression.R \
@@ -234,6 +236,7 @@ Rscript plots/scripts/0-plot_predictor_category_distributions.R \
 Rscript plots/scripts/3-plot_category_kappa.R \
   --cancer_type GBM \
   --predictor TP53 \
+  --null_model \
   --output_directory plots/main
 
 # ------------------------------------------------------------------------------
@@ -260,6 +263,7 @@ Rscript plots/scripts/0-plot_predictor_category_distributions.R \
 Rscript plots/scripts/3-plot_category_kappa.R \
   --cancer_type GBM \
   --predictor PIK3CA \
+  --null_model \
   --output_directory plots/supplementary
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Stacking off of envest/check_md5sum_downloads

The intention of these changes is to clean up some of those helpful, loud screen outputs generated by R.

- When grouping by more than two variables, R4 tidyverse wants to use `.groups = "drop"` inside `summarize()` instead of simply `ungroup()` afterward.
- `write_tsv()` now prefes `file = ` instead of `path =`. These are both positional arguments and are in the same position both R3 and R4 tidyverse. So I just dropped the name of argument...

Functional testing shows all is good :) Thanks!