### PR TITLE
Make internal style more consistent, copy edits, add TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The models were trained to predict tumor subtype (5 classes), and the binary mut
   - _Unsupervised learning_: 
 Holdout sets were projected onto and back out of the training set space using Principal Components Analysis to obtain reconstructed holdout sets.
 The trained subtype classifiers were used to predict on the reconstructed holdout sets.
-[PLIER](https://github.com/wgmao/PLIER) (Pathway-Level Information ExtractoR) identified coordinated sets of genes pathways in each cancer type.
+[PLIER](https://github.com/wgmao/PLIER) (Pathway-Level Information ExtractoR) identified coordinated sets of genes in each cancer type.
 
 ### Differential Expression Pipeline
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # Cross-platform normalization enables machine learning model training on microarray and RNA-seq data simultaneously
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Summary](#summary)
+- [Requirements](#requirements)
+  - [Obtaining and running the Docker container](#obtaining-and-running-the-docker-container)
+- [Download data from The Cancer Genome Atlas (TCGA)](#download-data-from-the-cancer-genome-atlas-tcga)
+- [Recreate manuscript results](#recreate-manuscript-results)
+- [Methods](#methods)
+  - [Machine Learning Pipeline](#machine-learning-pipeline)
+  - [Differential Expression Pipeline](#differential-expression-pipeline)
+- [Running individual experiments](#running-individual-experiments)
+    - [Machine learning](#machine-learning)
+    - [Differential expression](#differential-expression)
+    - [Other scripts](#other-scripts)
+- [Manuscript versions](#manuscript-versions)
+- [Funding](#funding)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Summary
 
 We performed a series of supervised and unsupervised machine learning 
@@ -16,6 +37,8 @@ We evaluated six normalization approaches for all methods:
 5. [Training Distribution Matching](https://peerj.com/articles/1621/) (TDM)
 6. z-scoring (Z)
 
+
+
 ## Requirements
 
 We recommend using the docker image `envest/rnaseq_titration_results:R-4.1.2` to handle package and dependency installation.
@@ -23,7 +46,7 @@ See `docker/R-4.1.2/Dockerfile` for more information.
 
 Our analysis ([v2.0](https://github.com/greenelab/RNAseq_titration_results/releases/tag/v2.0)) was run using 7 cores on an AWS instance with 16 cores, 128 GB memory, and an allocated 1 TB of space.
 
-#### Setting up the docker container
+### Obtaining and running the Docker container
 
 Pull the docker image using:
 
@@ -37,7 +60,8 @@ Then run the command to start up a container, replacing <PASSWORD> with your own
 docker run --mount type=bind,target=/home/rstudio,source=$PWD -e PASSWORD=<PASSWORD> -p 8787:8787 envest/rnaseq_titration_results:R-4.1.2
 ```
 
-Navigate to http://localhost:8787/ and login to the RStudio server with the username `rstudio` and the password you set above.
+Navigate to <http://localhost:8787/> and login to the RStudio server with the username `rstudio` and the password you set above.
+
 
 ## Download data from The Cancer Genome Atlas (TCGA)
 
@@ -46,8 +70,9 @@ is [available at zenodo](https://zenodo.org/record/58862).
 
 Data from 150 glioblastoma (GBM) patients is available from the [Genomic Data Commons PanCan Atlas](https://gdc.cancer.gov/about-data/publications/pancanatlas).
 
+To download data, run the data download script in the top directory:
+
 ```
-# To download data, run the data download script in the top directory:
 bash download_TCGA_data.sh
 ```
 
@@ -60,6 +85,7 @@ bash run_all_analyses_and_plots.sh
 ```
 
 with [v2.0](https://github.com/greenelab/RNAseq_titration_results/releases/tag/v2.0) of this repository will reproduce the results presented in our manuscript.
+We recommend running all analyses within the project Docker container.
 
 ## Methods
 
@@ -67,7 +93,7 @@ with [v2.0](https://github.com/greenelab/RNAseq_titration_results/releases/tag/v
 
 Here's a schematic overview of our machine learning experiments:
 
-![](https://github.com/greenelab/RNAseq_titration_results/blob/master/diagrams/RNA-seq_titration_ML_overview.png?raw=true)
+![](diagrams/RNA-seq_titration_ML_overview.png)
 
 **Overview of supervised and unsupervised machine learning experiments.** 
 
@@ -76,19 +102,19 @@ Here's a schematic overview of our machine learning experiments:
 3. Machine learning applications
 
   - _Supervised learning_: 
-Three classifiers - LASSO, linear SVM, and Random Forest — were trained on each training set and tested on the microarray and RNA-seq holdout sets.
+Three classifiers – LASSO, linear SVM, and Random Forest — were trained on each training set and tested on the microarray and RNA-seq holdout sets.
 The models were trained to predict tumor subtype (5 classes), and the binary mutation status of _TP53_ and _PIK3CA_.
 
   - _Unsupervised learning_: 
 Holdout sets were projected onto and back out of the training set space using Principal Components Analysis to obtain reconstructed holdout sets.
 The trained subtype classifiers were used to predict on the reconstructed holdout sets.
-[PLIER](https://github.com/wgmao/PLIER) (Pathway-Level Information ExtractoR) identified active gene expression pathways in each cancer type.
+[PLIER](https://github.com/wgmao/PLIER) (Pathway-Level Information ExtractoR) identified coordinated sets of genes pathways in each cancer type.
 
 ### Differential Expression Pipeline
 
 Here's a schematic overview of our main differential expression experiment:
 
-![](https://github.com/greenelab/RNAseq_titration_results/blob/master/diagrams/RNA-seq_titration_diff_expression_overview.png?raw=true)
+![](diagrams/RNA-seq_titration_diff_expression_overview.png)
 
 **Overview of differential expression experiment.** 
 
@@ -108,8 +134,9 @@ In the "small n" experiment, between 3 and 50 samples were selected from each su
 
 #### Machine learning
 
+To run the machine learning pipeline, run in top directory:
+
 ```
-# To run the machine learning pipeline, run in top directory:
 bash run_machine_learning_experiments.sh [cancer type] [prediction task] [n cores]
 ```
 
@@ -121,11 +148,11 @@ where
 
 #### Differential expression
 
-```
-# Note: This requires the data to be processed to include matched samples only, 
-# and split into training and test sets (0-expression_data_overlap_and_split.R)
+⚠️ _This requires the data to be processed to include matched samples only, and split into training and test sets via `0-expression_data_overlap_and_split.R` in the machine learning pipeline._
 
-# To run the differential expression pipeline, run in top directory:
+To run the differential expression pipeline, run in top directory:
+
+```
 bash run_differential_expression_experiments.sh [cancer type] [subtype vs others] [subtype vs subtype] [subtype vs subtype small] [n cores]
 ```
 
@@ -133,8 +160,8 @@ where
 
 - `[cancer type]` is `BRCA` or `GBM`
 - `[subtype vs others]` is the subtype to be compared against all other subtypes
-- `[subtype vs subtype]` are the two subtypes to be compared (comma-separated, e.g. Her2,LumA)
-- `[subtype vs subtype small]` are the two subtypes to be compared at small sample sizes (comma-separated, e.g. Her2,LumA)
+- `[subtype vs subtype]` are the two subtypes to be compared (comma-separated, e.g. `Her2,LumA`)
+- `[subtype vs subtype small]` are the two subtypes to be compared at small sample sizes (comma-separated, e.g. `Her2,LumA`)
 - `[n cores]` is the number of cores you want to run in parallel
 
 #### Other scripts


### PR DESCRIPTION
I thought this might be a more straightforward way to make my suggestions @envest. I'll summarize my changes:

- I've pulled out the comments in the code chunks with instructions for running the code because I've finally been convinced by other members of the team that people are less likely to read comments in the code chunks. 
- I've added a table of contents with [`doctoc`](https://github.com/thlorenz/doctoc)
- I don't think we need to use URLs for the diagrams? I can't think of why that would be necessary.
- Small wordsmithing/style changes