### PR TITLE
Envest/121 permute plier

### DIFF
--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -46,8 +46,6 @@ initial.seed <- opt$seed
 set.seed(initial.seed)
 message(paste("\nPLIER initial seed set to:", initial.seed))
 
-print(permute)
-
 # define directories
 data.dir <- here::here("data")
 norm.data.dir <- here::here("normalized_data")

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -19,6 +19,7 @@ option_list <- list(
                         help = "Set the number of cores to use"
   ),
   optparse::make_option("--permute",
+                        action = "store_true",
                         default = FALSE,
                         help = "Permute the pathway-gene relationship matrix")
 )
@@ -44,6 +45,8 @@ permute <- opt$permute
 initial.seed <- opt$seed
 set.seed(initial.seed)
 message(paste("\nPLIER initial seed set to:", initial.seed))
+
+print(permute)
 
 # define directories
 data.dir <- here::here("data")

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -66,7 +66,10 @@ norm.train.files <- file.path(
 # define output files
 plot_data_filename <- file.path(
   plot.data.dir,
-  str_c(file_identifier, "_PLIER_jaccard.tsv")
+  str_c(file_identifier, "_PLIER_jaccard",
+        ifelse(permute, # distinguish between permuted/not permuted output files
+               ".permuted.tsv",
+               ".tsv"))
 )
 
 #### set up PLIER data ---------------------------------------------------------
@@ -433,7 +436,8 @@ if (length(jaccard_list) > 0) {
       "nmeth" = "L3", # normalization method
       "pseq" = "L2", # percentage RNA-seq
       "seed_index" = "L1"
-    )
+    ) %>%
+    mutate(genes_pathways_permuted = permute)
   
   readr::write_tsv(jaccard_df,
                    plot_data_filename

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -87,21 +87,21 @@ all.paths <- PLIER::combinePaths(
 )
 
 # Do permutation here only if we want to permute once and re-use the same permuted matrix
-if (permute) {
+#if (permute) {
 
   ### Option 1 for permuting all.paths:
   # permutes only the row names (gene names)
   # keeps all 0-1 values in the same place
-  row.names(all.paths) <- sample(row.names(all.paths))
+  #row.names(all.paths) <- sample(row.names(all.paths))
   
   ### Option 2 for permuting all.paths:
   # permutes all 0-1 values within column (pathway)
   # keeps row names the same
-  all.paths.row.names <- row.names(all.paths)
-  all.paths <- apply(all.paths, 2, sample)
-  row.names(all.paths) <- all.paths.row.names
+  #all.paths.row.names <- row.names(all.paths)
+  #all.paths <- apply(all.paths, 2, sample)
+  #row.names(all.paths) <- all.paths.row.names
 
-}
+#}
 
 PLIER_pathways <- colnames(all.paths)
 
@@ -292,7 +292,7 @@ for (seed_index in 1:length(norm.train.files)) {
   # set random seeds to use inside %dopar% loop for each %seq and norm method
   use_seeds_inside_dopar <- list()
   for (ps in perc_seq) {
-    #use_seeds_inside_dopar[[ps]] <- list()
+    
     if (ps %in% c("0", "100")) {
       for (nm in norm_methods_if_0_100) {
         print(ps)
@@ -361,7 +361,7 @@ for (seed_index in 1:length(norm.train.files)) {
           ### Option 1 for permuting all.paths:
           # permutes only the row names (gene names)
           # keeps all 0-1 values in the same place
-          row.names(all.paths) <- sample(row.names(all.paths))
+          #row.names(all.paths) <- sample(row.names(all.paths))
           
           ### Option 2 for permuting all.paths:
           # permutes all 0-1 values within column (pathway)

--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -86,23 +86,6 @@ all.paths <- PLIER::combinePaths(
   svmMarkers
 )
 
-# Do permutation here only if we want to permute once and re-use the same permuted matrix
-#if (permute) {
-
-  ### Option 1 for permuting all.paths:
-  # permutes only the row names (gene names)
-  # keeps all 0-1 values in the same place
-  #row.names(all.paths) <- sample(row.names(all.paths))
-  
-  ### Option 2 for permuting all.paths:
-  # permutes all 0-1 values within column (pathway)
-  # keeps row names the same
-  #all.paths.row.names <- row.names(all.paths)
-  #all.paths <- apply(all.paths, 2, sample)
-  #row.names(all.paths) <- all.paths.row.names
-
-#}
-
 PLIER_pathways <- colnames(all.paths)
 
 #### Function for converting column to row names -------------------------------
@@ -295,14 +278,10 @@ for (seed_index in 1:length(norm.train.files)) {
     
     if (ps %in% c("0", "100")) {
       for (nm in norm_methods_if_0_100) {
-        print(ps)
-        print(nm)
         use_seeds_inside_dopar[[ps]][[nm]] <- sample(1:1000, size = 1)
       }
     } else {
       for (nm in norm_methods_else) {
-        print(ps)
-        print(nm)
         use_seeds_inside_dopar[[ps]][[nm]] <- sample(1:1000, size = 1)
       }
     }
@@ -355,15 +334,9 @@ for (seed_index in 1:length(norm.train.files)) {
           norm.train.list[[ps]][[nm]] <- norm.train.list[[ps]][[nm]][-all.same.indx, ]
         }
 
-        # Do permutation here only if we want to permute every time and never re-use the same permuted matrix
+        # Permute every time and never re-use the same permuted matrix
         if (permute) {
           
-          ### Option 1 for permuting all.paths:
-          # permutes only the row names (gene names)
-          # keeps all 0-1 values in the same place
-          #row.names(all.paths) <- sample(row.names(all.paths))
-          
-          ### Option 2 for permuting all.paths:
           # permutes all 0-1 values within column (pathway)
           # keeps row names the same
           all.paths.row.names <- row.names(all.paths)

--- a/plots/scripts/7-plot_plier_pathways.R
+++ b/plots/scripts/7-plot_plier_pathways.R
@@ -47,7 +47,7 @@ output_filename <- file.path(output_directory,
 
 # Read in data
 jaccard_df <- read_tsv(plot_data_filename,
-                       col_types = "dddddcdcdd") %>%
+                       col_types = "dddddcdcddl") %>%
   filter(pseq == 50) %>%
   mutate(sample_size = case_when(nmeth == "array_only" ~ "Single Platform",
                                  nmeth == "seq_only" ~ "Single Platform",

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -22,15 +22,14 @@ if [ $predictor == "TP53" ] || [ $predictor == "PIK3CA" ]; then
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model --ncores $ncores
 else
-  #Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
-  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 3 --ncores $ncores
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
 fi
 
 # Run the unsupervised analyses using subtype models
 if [ $predictor == "subtype" ]; then
-#  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
-#  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
-#  Rscript 6-save_recon_error_kappa_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
+  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 6-save_recon_error_kappa_data.R --cancer_type $cancer_type --predictor $predictor
   Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores --permute FALSE
   Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores --permute TRUE
 fi

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -22,13 +22,15 @@ if [ $predictor == "TP53" ] || [ $predictor == "PIK3CA" ]; then
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
   Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model --ncores $ncores
 else
-  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
+  #Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 3 --ncores $ncores
 fi
 
 # Run the unsupervised analyses using subtype models
 if [ $predictor == "subtype" ]; then
-  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
-  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
-  Rscript 6-save_recon_error_kappa_data.R --cancer_type $cancer_type --predictor $predictor
-  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores
+#  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
+#  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
+#  Rscript 6-save_recon_error_kappa_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores --permute FALSE
+  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores --permute TRUE
 fi

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -18,18 +18,18 @@ fi
 
 # Run ten repeats of the supervised analysis
 # if the predictor is a gene, also generate null models
-if [ $predictor == "TP53" ] || [ $predictor == "PIK3CA" ]; then
-  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
-  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model --ncores $ncores
-else
-  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
-fi
+#if [ $predictor == "TP53" ] || [ $predictor == "PIK3CA" ]; then
+#  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
+#  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model --ncores $ncores
+#else
+  #Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
+#fi
 
 # Run the unsupervised analyses using subtype models
 if [ $predictor == "subtype" ]; then
-  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
-  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
-  Rscript 6-save_recon_error_kappa_data.R --cancer_type $cancer_type --predictor $predictor
-  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores --permute FALSE
-  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores --permute TRUE
+  #Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
+  #Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
+  #Rscript 6-save_recon_error_kappa_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores
+  Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores --permute
 fi

--- a/run_machine_learning_experiments.sh
+++ b/run_machine_learning_experiments.sh
@@ -18,18 +18,18 @@ fi
 
 # Run ten repeats of the supervised analysis
 # if the predictor is a gene, also generate null models
-#if [ $predictor == "TP53" ] || [ $predictor == "PIK3CA" ]; then
-#  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
-#  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model --ncores $ncores
-#else
-  #Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
-#fi
+if [ $predictor == "TP53" ] || [ $predictor == "PIK3CA" ]; then
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --null_model --ncores $ncores
+else
+  Rscript classifier_repeat_wrapper.R --cancer_type $cancer_type --predictor $predictor --n_repeats 10 --ncores $ncores
+fi
 
 # Run the unsupervised analyses using subtype models
 if [ $predictor == "subtype" ]; then
-  #Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
-  #Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
-  #Rscript 6-save_recon_error_kappa_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 4-ica_pca_feature_reconstruction.R --cancer_type $cancer_type --predictor $predictor --n_components 50
+  Rscript 5-predict_category_reconstructed_data.R --cancer_type $cancer_type --predictor $predictor
+  Rscript 6-save_recon_error_kappa_data.R --cancer_type $cancer_type --predictor $predictor
   Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores
   Rscript 7-extract_plier_pathways.R --cancer_type $cancer_type --ncores $ncores --permute
 fi


### PR DESCRIPTION
Closes #121 

We want to be able to run PLIER using a permuted gene-pathways matrix that removes biological relationships. Understanding how often we get significant results from the permuted experiment contextualizes the rate of significant results we get from the un-permuted experiment.

This PR adds an option to `7-extract_plier_pathways.R` to permute the columns of the gene-pathway matrix given to PLIER. Each column of the gene-pathway matrix is permuted with `sample()`, so each pathway retains the same number of genes. The row names do not change. A different permutation is used for each PLIER run, each with its own seed that gets reset within the parallel loop.

`7-extract_plier_pathways.R` is run once with `permute = FALSE` and once with `permute = TRUE`. The two output tables can become supplementary tables. The plotting script is unchanged except for adding a new "logical" column in `read_tsv`.