### PR TITLE
Envest/122 crossnorm

### DIFF
--- a/docker/R-4.1.2/Dockerfile
+++ b/docker/R-4.1.2/Dockerfile
@@ -76,15 +76,6 @@ RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
     update = FALSE, \
     version = 3.14)"
 
-# Threading issue with preprocessCore::normalize.quantiles
-# https://support.bioconductor.org/p/122925/#124701
-# https://github.com/bmbolstad/preprocessCore/issues/1#issuecomment-326756305
-#RUN Rscript -e "options(warn = 2); BiocManager::install( \
-#    'preprocessCore', \
-#    configure.args = '--disable-threading', \
-#    force = TRUE, \
-#    update = FALSE)"
-
 # ref = 341eb77105e7efd2654b4f112578648584936e06 is latest greenelab/TDM commit (retrieved 2021-05-28)
 RUN Rscript -e "options(warn = 2); remotes::install_github( \
     'greenelab/TDM', ref = 'b041807835d4076c5549356c86c44f087d713b1a')"

--- a/docker/R-4.1.2/Dockerfile
+++ b/docker/R-4.1.2/Dockerfile
@@ -56,8 +56,19 @@ RUN install2.r --error --deps TRUE \
     styler \
     viridis
 
+# Threading issue with preprocessCore::normalize.quantiles
+# https://support.bioconductor.org/p/122925/#124701
+# https://github.com/bmbolstad/preprocessCore/issues/1#issuecomment-326756305
+RUN Rscript -e "options(warn = 2); BiocManager::install( \
+    'preprocessCore', \
+    configure.args = '--disable-threading', \
+    force = TRUE, \
+    update = FALSE, \
+    version = 3.14)"
+
 # R Bioconductor packages
 RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
+    'affy', \
     'EnsDb.Hsapiens.v86' , \
     'ensembldb', \
     'limma', \
@@ -68,11 +79,11 @@ RUN Rscript -e "options(warn = 2); BiocManager::install(c( \
 # Threading issue with preprocessCore::normalize.quantiles
 # https://support.bioconductor.org/p/122925/#124701
 # https://github.com/bmbolstad/preprocessCore/issues/1#issuecomment-326756305
-RUN Rscript -e "options(warn = 2); BiocManager::install( \
-    'preprocessCore', \
-    configure.args = '--disable-threading', \
-    force = TRUE, \
-    update = FALSE)"
+#RUN Rscript -e "options(warn = 2); BiocManager::install( \
+#    'preprocessCore', \
+#    configure.args = '--disable-threading', \
+#    force = TRUE, \
+#    update = FALSE)"
 
 # ref = 341eb77105e7efd2654b4f112578648584936e06 is latest greenelab/TDM commit (retrieved 2021-05-28)
 RUN Rscript -e "options(warn = 2); remotes::install_github( \

--- a/util/CrossNorm.R
+++ b/util/CrossNorm.R
@@ -2,10 +2,10 @@
 # Cheng, L., Lo, L.-Y., Tang, N. L. S., Wang, D. & Leung, K.-S. CrossNorm: a novel normalization strategy for microarray data in cancers. Sci. Rep. 6, 18898 (2016)
 # https://www.nature.com/articles/srep18898
 
-# Specifically, the code is copied directly without modification from the supplementary information here:
+# The code is copied without modification from the Supplementary Information here:
 # https://static-content.springer.com/esm/art%3A10.1038%2Fsrep18898/MediaObjects/41598_2016_BFsrep18898_MOESM1_ESM.pdf
 
-# We thank the authors for making the code publicly available under a Creative Commons CC BY license.
+# We thank the authors of CrossNorm for making the code publicly available under a Creative Commons CC BY license.
 
 #====================================================================================
 # Description:

--- a/util/CrossNorm.R
+++ b/util/CrossNorm.R
@@ -1,0 +1,93 @@
+# The following code implements the CrossNorm algorithm with quantile normalization as described in
+# Cheng, L., Lo, L.-Y., Tang, N. L. S., Wang, D. & Leung, K.-S. CrossNorm: a novel normalization strategy for microarray data in cancers. Sci. Rep. 6, 18898 (2016)
+# https://www.nature.com/articles/srep18898
+
+# Specifically, the code is copied directly without modification from the supplementary information here:
+# https://static-content.springer.com/esm/art%3A10.1038%2Fsrep18898/MediaObjects/41598_2016_BFsrep18898_MOESM1_ESM.pdf
+
+# We thank the authors for making the code publicly available under a Creative Commons CC BY license.
+
+#====================================================================================
+# Description:
+# Cross Normalization (CrossNorm) for gene expression data.
+#
+# Arguments:
+# exp - a (non-empty) numeric matrix of data values. Row represents gene while
+# colum represents sample.
+# label - a (non-empty) binary vector of data values in which ’0’ represents
+# control sample and ’1’ reptesents disease sample. The length of label
+# should be equal to the column number of exp.
+# Value:
+# exp.crossnorm - A normalized numeric matrix. Row represents gene while column
+# represents sample. The gene order is the same as exp.
+#
+# Reference:
+# CrossNorm: a novel normalization strategy for microarray data in cancers
+# Lixin Cheng, Leung-Yau Lo, Kwong-Sak Leung, Nelson LS Tang and Dong Wang
+#
+# Example:
+# source("CrossNorm.R")
+# exp.pcn = PairedCrossNorm(exp, label)
+# exp.gcn = GeneralCrossNorm(exp, label)
+#====================================================================================
+
+library(affy)
+library(preprocessCore)
+
+# -------------------Paired CrossNorm --------------------
+
+PairedCrossNorm <- function(exp, label){
+  exp = as.matrix(exp);
+  geneLen = dim(exp)[1];
+  exp.normal = exp[,label==0];
+  exp.disease = exp[,label==1];
+  exp.cross = rbind(exp.normal,exp.disease);
+  exp.quantile.cross = normalize.quantiles(exp.cross);
+  exp.crossnorm.normal = exp.quantile.cross[1:geneLen,];
+  exp.crossnorm.disease = exp.quantile.cross[(geneLen+1):(2*geneLen),];
+  exp.crossnorm= cbind(exp.crossnorm.normal,exp.crossnorm.disease);
+  return(exp.crossnorm)
+}
+
+# ---------------- General CrossNorm --------------------
+
+GeneralCrossNorm <- function(exp,label){
+  exp = as.matrix(exp);
+  exp.cross = Matrix2CrossMatrix(exp,label)
+  exp.quantile.cross = normalize.quantiles(exp.cross)
+  exp.crossnorm = CrossMatrix2Matrix(exp.quantile.cross,label)
+  return(exp.crossnorm)
+}
+
+# CrossMatrix
+Matrix2CrossMatrix <- function(M, label){
+  M = as.matrix(M)
+  rowLen = dim(M)[1]
+  sampleSize1 = sum(label==1) # disease sample size
+  sampleSize0 = sum(label==0) # normal sample size
+  indexMatrix = matrix(1:(sampleSize1*sampleSize0),,sampleSize0)
+  M1 = M[,label==1]
+  M0 = M[,label==0]
+  M3 = matrix(0,rowLen*2,sampleSize1*sampleSize0)
+  for (t in 1:sampleSize1){
+    M3[,indexMatrix[t,]] = rbind(matrix(rep(M1[,t],sampleSize0),,sampleSize0),M0)
+  }
+  return(M3)
+}
+
+CrossMatrix2Matrix <- function(CrossM,label){
+  rowLen = dim(CrossM)[1]/2
+  sampleSize1 = sum(label==1) # disease sample size
+  sampleSize0 = sum(label==0) # normal sample size
+  indexMatrix = matrix(1:(sampleSize1*sampleSize0),,sampleSize0)
+  M1 = matrix(0,rowLen,sampleSize1)
+  M0 = matrix(0,rowLen,sampleSize0)
+  for(t in 1:sampleSize1){
+    M1[,t] = apply(CrossM[1:rowLen,indexMatrix[t,]],1,mean)
+  }
+  for(t in 1:sampleSize0){
+    M0[,t] = apply(CrossM[(rowLen+1):(rowLen*2),indexMatrix[,t]],1,mean)
+  }
+  M = cbind(M0,M1)
+  return(M)
+}

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -1204,13 +1204,13 @@ rescale_01 <- function(data_vector){
   }
 }
 
-rescale_datatable <- function(data_table, by_row = TRUE){
+rescale_datatable <- function(data_table, by_column = FALSE){
   # rescale each row (or column) of a data table to [0,1]
   # applies rescale_01() to each row (or column)
   # Inputs: gene expression data table
   #   first column of input is genes
   #   remaining columns are expression values
-  #   by_row = TRUE rescale each row, if FALSE rescale each column
+  #   by_column = FALSE rescale each row, if TRUE rescale each column
   # Returns: scaled gene expression data table
   
   data_table <- ensure_numeric_gex(data_table)
@@ -1218,12 +1218,11 @@ rescale_datatable <- function(data_table, by_row = TRUE){
   data_matrix = data.matrix(data_table[, -1, with = F])
   
   # Rescale each row or column [0,1]
-  if (by_row) {
-    rescaled_data_matrix = t(apply(data_matrix, 1, rescale_01))
-  } else {
+  if (by_column) {
     rescaled_data_matrix = apply(data_matrix, 2, rescale_01)
+  } else {
+    rescaled_data_matrix = t(apply(data_matrix, 1, rescale_01))
   }
-  
   
   # Include gene symbols in result
   result = data.table(data.frame(data_table[,1], rescaled_data_matrix))

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -953,8 +953,8 @@ CNProcessing <-  function(array.dt, seq.dt,
   seq.colnames <- names(seq.dt)
   
   if (scale_inputs) {
-    array.dt <- rescale_datatable(array.dt)
-    seq.dt <- rescale_datatable(seq.dt)
+    array.dt <- rescale_datatable(array.dt, by_row = FALSE)
+    seq.dt <- rescale_datatable(seq.dt, by_row = FALSE)
   }
 
   n_array <- ncol(array.dt[,-1])
@@ -1159,21 +1159,27 @@ rescale_01 <- function(data_vector){
   }
 }
 
-rescale_datatable <- function(data_table){
-  # rescale each row of a data table to [0,1]
-  # applies rescale_01() to each row
+rescale_datatable <- function(data_table, by_row = TRUE){
+  # rescale each row (or column) of a data table to [0,1]
+  # applies rescale_01() to each row (or column)
   # Inputs: gene expression data table
   #   first column of input is genes
   #   remaining columns are expression values
+  #   by_row = TRUE rescale each row, if FALSE rescale each column
   # Returns: scaled gene expression data table
   
   data_table <- ensure_numeric_gex(data_table)
   
   data_matrix = data.matrix(data_table[, -1, with = F])
   
-  # Rescale each row [0,1]
-  rescaled_data_matrix = t(apply(data_matrix, 1, rescale_01))
-    
+  # Rescale each row or column [0,1]
+  if (by_row) {
+    rescaled_data_matrix = t(apply(data_matrix, 1, rescale_01))
+  } else {
+    rescaled_data_matrix = apply(data_matrix, 2, rescale_01)
+  }
+  
+  
   # Include gene symbols in result
   result = data.table(data.frame(data_table[,1], rescaled_data_matrix))
   colnames(result) <- colnames(data_table)

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -955,8 +955,8 @@ CNProcessing <-  function(array.dt, seq.dt,
   # if the inputs are on different scales (array and RNA-seq usually are), scale
   # each sample (column) to be on the same 0-1 scale
   if (scale_inputs) {
-    array.dt <- rescale_datatable(array.dt, by_row = FALSE)
-    seq.dt <- rescale_datatable(seq.dt, by_row = FALSE)
+    array.dt <- rescale_datatable(array.dt, by_column = TRUE)
+    seq.dt <- rescale_datatable(seq.dt, by_column = TRUE)
   }
 
   # The number of array and RNA-seq samples

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -1,3 +1,5 @@
+source(here::here("util", "CrossNorm.R"))
+
 NAToZero <- function(dt, un=0) suppressWarnings(gdata::NAToUnknown(dt, un, force = TRUE))
 
 #### single platform functions -------------------------------------------------

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -910,9 +910,9 @@ CNProcessing <-  function(array.dt, seq.dt,
   
   # This function takes array and RNA-seq data in the form of data.table
   # to be 'mixed' (concatenated) and applies the CrossNorm normalization method.
-  # Columns of the two inputs may be paired (default, not paired)
-  # The two input data sets need to be on the same scale (scale_inputs for 0-1).
-  # To be consistent with other methods, we also scale the final matrix 0-1.
+  # Columns of the two inputs may be paired (default: not paired)
+  # The two input data sets should be scaled 0-1 on the sample level (column).
+  # To be consistent with other methods, we also scale the final matrix gene-wise 0-1.
   # For now, the normalization method available is "quantile".
   #
   # Args:
@@ -923,8 +923,8 @@ CNProcessing <-  function(array.dt, seq.dt,
   #             gene identifiers, the columns are samples,
   #             rows are gene measurements
   #   paired:   are the columns of array and seq paired (like case/control?)
-  #   scale_inputs:  TRUE if array and seq data are on different scales to start with
-  #   zero.to.one: logical - should data be zero to one transformed?
+  #   scale_inputs: logical - scale columns if inputs are on different scales to start with
+  #   zero.to.one: logical - should data be gene-wise zero to one transformed?
   #   norm_method: the normalization method applied (default: quantile)
   #
   # Returns:
@@ -952,15 +952,19 @@ CNProcessing <-  function(array.dt, seq.dt,
   array.colnames <- names(array.dt)
   seq.colnames <- names(seq.dt)
   
+  # if the inputs are on different scales (array and RNA-seq usually are), scale
+  # each sample (column) to be on the same 0-1 scale
   if (scale_inputs) {
     array.dt <- rescale_datatable(array.dt, by_row = FALSE)
     seq.dt <- rescale_datatable(seq.dt, by_row = FALSE)
   }
 
-  n_array <- ncol(array.dt[,-1])
-  n_seq <- ncol(seq.dt[,-1])
+  # The number of array and RNA-seq samples
+  n_array <- ncol(array.dt) - 1
+  n_seq <- ncol(seq.dt) - 1
   
-  if (paired) {
+  # Create the combined data matrix that will be normalized
+  if (paired) { # if the inputs are paired, simply stack the two inputs
     
     if (n_array == n_seq) {
       combined.dt <- rbind(array.dt, seq.dt)[,-1]
@@ -968,13 +972,26 @@ CNProcessing <-  function(array.dt, seq.dt,
       stop("Number of array and seq columns must be same for paired CrossNorm")
     }
     
-  } else {
+  } else { # if the inputs are not paired, then each array sample is matched
+    # with each seq sample to create a matrix with n_array*n_seq columns
     
+    # example, with 3 array samples (a1, a2, a3) and 2 seq samples (s1, s2)
+    # a1 a1 a2 a2 a3 a3
+    # s1 s2 s1 s2 s1 s2
+    # where each element a1, a2, a3, s1, s2 is a vector of length n_genes
+    # creating a combined matrix with dimensions (2*n_genes) x (n_array*n_seq)
+    # (this is the cross of crossnorm)
+    
+    # the array component of the combined matrix must repeat each array column n_seq times
     wide_array.dt <- t(apply(array.dt[,-1], 1, function(x) rep(x, each = n_seq)))
+    
+    # the seq component of the combined matrix must repeat its entire self n_array times
+    # here, we allow the final dimensions of the matrix and then seq.dt[-1] is recycled to fill it
     wide_seq.dt <- matrix(as.matrix(seq.dt[,-1]),
                           nrow = n_genes,
                           ncol = n_seq*n_array)
     
+    # then cat the array and seq components together
     combined.dt <- rbind(wide_array.dt, wide_seq.dt)
   }
   
@@ -989,22 +1006,50 @@ CNProcessing <-  function(array.dt, seq.dt,
     
   }
   
-  normed.array.dt <- sapply(lapply(1:n_array,
-                                   function(x) normed.combined.dt[1:n_genes,
-                                                                  (n_seq*x - n_seq + 1):(n_seq*x)]),
+  if (paired) {
+    
+    # the top half of the combined matrix
+    normed.array.dt <- normed.combined.dt[1:n_genes,]
+    # the bottom half of the combined matrix
+    normed.seq.dt <- normed.combined.dt[(n_genes + 1):(2*n_genes),]
+    
+  } else {
+    
+    # now with a cross-normalized matrix, we have
+    # a1n a1n a2n a2n a3n a3n
+    # s1n s2n s1n s2n s1n s2n
+    # where each element has now been normalized within its column
+    # now we need to find the gene-level mean of each element from the same sample
+    # i.e. vector_mean_of(each a1n), ... vector_mean_of(each s2n)
+  
+    # for array values, that is the top half of the combined data table (1:n_genes)
+    # and chunks of columns (in the example, columns 1:2, 3:4, 5:6)
+    normed.array.dt <- sapply(lapply(1:n_array,
+                                     function(x) normed.combined.dt[1:n_genes,
+                                                                    (n_seq*x - n_seq + 1):(n_seq*x)]),
+                              rowMeans,
+                              simplify = TRUE)
+    
+    # for array values, that is the bottom half of the combined data table (n_genes + 1:(2*n_genes)
+    # and particular columns (in the example, columns 1,3,5 and 2,4,6)
+    normed.seq.dt <- sapply(lapply(1:n_seq,
+                                   function(x) normed.combined.dt[(n_genes + 1):(2*n_genes),
+                                                                  1:(n_seq*n_array) %% n_seq == (x %% n_seq)]),
                             rowMeans,
                             simplify = TRUE)
+    
+  }
   
-  normed.seq.dt <- sapply(lapply(1:n_seq,
-                                 function(x) normed.combined.dt[(n_genes + 1):(2*n_genes),
-                                                                1:(n_seq*n_array) %% n_seq == (x %% n_seq)]),
-                                 rowMeans,
-                                 simplify = TRUE)
-  
+  # cbind it all together, and include column names
   cn.cat <- data.table(cbind(gene_names, normed.array.dt, normed.seq.dt))
   names(cn.cat) <- c(array.colnames, seq.colnames[-1])
   
   cn.cat <- ensure_numeric_gex(cn.cat)
+  
+  # rescale each gene to be 0-1
+  if (zero.to.one) {
+    cn.cat <- rescale_datatable(cn.cat)
+  }
   
   return(cn.cat)
   

--- a/util/normalization_functions.R
+++ b/util/normalization_functions.R
@@ -957,18 +957,18 @@ CNProcessing <-  function(array.dt, seq.dt,
     seq.dt <- rescale_datatable(seq.dt)
   }
 
+  n_array <- ncol(array.dt[,-1])
+  n_seq <- ncol(seq.dt[,-1])
+  
   if (paired) {
     
-    if (ncol(array.dt) == ncol(seq.dt)) {
+    if (n_array == n_seq) {
       combined.dt <- rbind(array.dt, seq.dt)[,-1]
     } else {
       stop("Number of array and seq columns must be same for paired CrossNorm")
     }
     
   } else {
-    
-    n_array <- ncol(array.dt[,-1])
-    n_seq <- ncol(seq.dt[,-1])
     
     wide_array.dt <- t(apply(array.dt[,-1], 1, function(x) rep(x, each = n_seq)))
     wide_seq.dt <- matrix(as.matrix(seq.dt[,-1]),


### PR DESCRIPTION
Closes #122 

We want to try another normalization method: CrossNorm. Well, CrossNorm itself is not a normalization method. It is a strategy for creating each combination of samples from two sets, doing some kind of normalization, and then averaging the effects of the normalization. The default normalization method is quantile, which we implement here. The two input sets can be paired (could be useful to somebody but not for us today) and unpaired (the default). In the paired setting, two samples (e.g. from the same patient) are normalized jointly. In the unpaired setting, each sample is normalized along with all other samples... this sample crossing seems to be the novelty of CrossNorm.

This PR creates `CNProcessing()`, in line with other normalization methods in `util/normalization_functions.R`. I envision using regular quantile normalization for 0% RNA-seq and 100% RNA-seq, and then using `CNProcessing()` for when we have both input types. The actual implementation of that will come later as a stacked PR depending on the timing of review 😄 thanks!

This PR also updates `rescale_datatable()` to make rescaling by row the default (no change in behavior) but allows the option to rescale by column (which is needed to get array and RNA-seq comparable for this normalization method).

One concern is thinking about the size of the crossed matrix... thinking about the 50% RNA-seq, with 520 BRCA samples, 2/3 of which are in training (~350 samples, 175 from array and 175 from RNA-seq)... with 12k genes, the cross matrix will be 12000x2 rows by 175x175 columns, with an object size ~5.5 GiB. If that turns out to be a problem, we can cross (ahem) that bridge later.