### PR TITLE
Envest/132 metrics

### DIFF
--- a/3-combine_category_kappa.R
+++ b/3-combine_category_kappa.R
@@ -157,12 +157,12 @@ readr::write_tsv(test.df,
 # get summary data.frame + write to file
 summary.df <- test.df %>%
   dplyr::group_by(Classifier, Normalization, Platform, Perc.Seq) %>%
-  dplyr::summarise(Median_Kappa = median(Kappa),
-                   Mean_Kappa = mean(Kappa),
-                   SD_Kappa = sd(Kappa),
-                   Median_AUC = median(AUC),
-                   Mean_AUC = mean(AUC),
-                   SD_AUC = sd(AUC),
+  dplyr::summarise(Median_Kappa = median(Kappa, na.rm = TRUE),
+                   Mean_Kappa = mean(Kappa, na.rm = TRUE),
+                   SD_Kappa = sd(Kappa, na.rm = TRUE),
+                   Median_AUC = median(AUC, na.rm = TRUE),
+                   Mean_AUC = mean(AUC, na.rm = TRUE),
+                   SD_AUC = sd(AUC, na.rm = TRUE),
                    .groups = "drop")
 
 readr::write_tsv(summary.df,

--- a/3-combine_category_kappa.R
+++ b/3-combine_category_kappa.R
@@ -111,7 +111,7 @@ if (null_model) {
                 by = c("perc.seq", "classifier", "norm.method"),
                 suffix = c(".true", ".null")) %>%
       mutate(delta_kappa = kappa.true - kappa.null) %>% # regular kappa - null kappa
-      select(delta_kappa, perc.seq, classifier, norm.method)
+      select(delta_kappa, auc.true, perc.seq, classifier, norm.method)
   }
   
 }
@@ -122,8 +122,10 @@ if (null_model) {
   array.df <- data.table::rbindlist(delta_kappa_array.list)
   seq.df <- data.table::rbindlist(delta_kappa_seq.list)
 } else {
-  array.df <- data.table::rbindlist(array.list)
-  seq.df <- data.table::rbindlist(seq.list)
+  array.df <- data.table::rbindlist(array.list) %>%
+    select(kappa, auc, perc.seq, classifier, norm.method)
+  seq.df <- data.table::rbindlist(seq.list) %>%
+    select(kappa, auc, perc.seq, classifier, norm.method)
 }
 
 #### save test set results -----------------------------------------------------
@@ -133,7 +135,7 @@ test.df <- cbind(rbind(array.df, seq.df),
                  c(rep("Microarray", nrow(array.df)),
                    rep("RNA-seq", nrow(seq.df))))
 
-colnames(test.df) <- c("Kappa", "Perc.Seq", "Classifier",
+colnames(test.df) <- c("Kappa", "AUC", "Perc.Seq", "Classifier",
                        "Normalization", "Platform")
 
 # order %seq to display 0-100
@@ -155,9 +157,12 @@ readr::write_tsv(test.df,
 # get summary data.frame + write to file
 summary.df <- test.df %>%
   dplyr::group_by(Classifier, Normalization, Platform, Perc.Seq) %>%
-  dplyr::summarise(Median = median(Kappa),
-                   Mean = mean(Kappa),
-                   SD = sd(Kappa),
+  dplyr::summarise(Median_Kappa = median(Kappa),
+                   Mean_Kappa = mean(Kappa),
+                   SD_Kappa = sd(Kappa),
+                   Median_AUC = median(AUC),
+                   Mean_AUC = mean(AUC),
+                   SD_AUC = sd(AUC),
                    .groups = "drop")
 
 readr::write_tsv(summary.df,

--- a/check_sums.tsv
+++ b/check_sums.tsv
@@ -3,14 +3,14 @@
 d4486dde14da14b4f8887a7415e2866f  data/BRCARNASeqClin.tsv
 1a89ea769381e300e5a88ec61713ad9e  data/BRCAarray.pcl
 02e72c33071307ff6570621480d3c90b  data/EBPlusPlusAdjustPANCAN_IlluminaHiSeq_RNASeqV2.geneExp.tsv
-90feb5edb48d7619568d2de21697509e  data/GBMClin.tsv
+ce911443e071c4251fb3f196780e76de  data/GBMClin.tsv
 949938abadd336eb9a2f698b3102e1bb  data/GBMRNASeq.pcl
 3bbdad11c322ebf3b03ada07263c6444  data/GBMarray.pcl
 e5df57691b44c47b8c916116b5ac7acf  data/PanCan-General_Open_GDC-Manifest_2.txt
 a4591b2dcee39591f59e5e25a6ce75fa  data/TCGA-CDR-SupplementalTableS1.xlsx
 7fafc537807d5b3ddf0bb89665279a9d  data/broad.mit.edu_PANCAN_Genome_Wide_SNP_6_whitelisted.seg
 d79d2399598ac2e6c11a1b44c5c603df  data/combined_clinical_data.BRCA.tsv
-90f745d4eac485168cb2b50be29104b1  data/combined_clinical_data.GBM.tsv
+7cd37ad1cde1c58ff76cb739bd376e5f  data/combined_clinical_data.GBM.tsv
 1d8834a51282396e07e3ce9a5417d024  data/gbm_clinical_table_S7.xlsx
 639ad8f8386e98dacc22e439188aa8fa  data/mc3.v0.2.8.PUBLIC.maf.gz
 7583a5fb4d23d50b79813b26469f6385  data/mutations.BRCA.tsv

--- a/plots/scripts/3-plot_category_kappa.R
+++ b/plots/scripts/3-plot_category_kappa.R
@@ -60,7 +60,7 @@ output_filename <- file.path(output_directory,
 
 # read in data
 plot_df <- read_tsv(input_filename,
-                    col_types = "ddccc") %>%
+                    col_types = "dddccc") %>%
   mutate(Perc.Seq = factor(Perc.Seq,
                            levels = seq(0, 100, 10)))
 

--- a/prepare_GBM_data.R
+++ b/prepare_GBM_data.R
@@ -202,6 +202,7 @@ gbm_subtypes <- readxl::read_xlsx(path = clinical_xlxs_input_filepath,
          "IDH1_mutation_status" = "IDH1\r\n status",
          "subtype" = "Expression\r\nSubclass") %>%
   mutate(subtype = na_if(subtype, "NA")) %>%
+  mutate(subtype = stringr::str_remove(subtype, "-")) %>% # G-CIMP to GCIMP
   mutate(Type = "tumor")
 
 missing_clinical <- gbm_subtypes %>%

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -322,7 +322,8 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
                             sample.df = sample.dataframe,
                             model.type = mdl.type)
           
-          return(c(kappa, auc))
+          return(data.frame("kappa" = kappa,
+                            "auc" = auc))
 
         }
 
@@ -395,8 +396,10 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
     kappa.df <- norm.list %>%
       # when there is null test data at a particular %RNA-seq, discard that null
       purrr::modify_depth(2, function(x) discard(x, is.null)) %>%
-      reshape2::melt()
-    colnames(kappa.df) <- c("kappa", "auc", "perc.seq", "classifier", "norm.method")
+      reshape2::melt() %>%
+      tidyr::pivot_wider(names_from = "variable",
+                         values_from = "value")
+    colnames(kappa.df) <- c("perc.seq", "classifier", "norm.method", "kappa", "auc")
     return(kappa.df)
   } else {  # otherwise, return two objects:
     # 1. the list of confusionMatrix objects (norm.list)

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -345,7 +345,9 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
     parallel::clusterExport(cl,
                             c("PredictCM",
                               "GetCM",
-                              "GetOrderedCategoryLabels"))
+                              "GetOrderedCategoryLabels",
+                              "PredictAUC",
+                              "mean_one_versus_all_AUC"))
   }
 
   norm.methods <- names(train.model.list)

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -141,7 +141,7 @@ TrainThreeModels <- function(dt, category, seed, folds.list){
 
     fit.control <- trainControl(method = "cv",
                                 number = 5, # 5-fold cross-validation
-                                savePredictions = TRUE,
+                                #savePredictions = TRUE,
                                 classProbs = TRUE,
                                 seeds = seed.list,
                                 index = folds.list, # list of 5 sets of indices

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -311,34 +311,47 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
         # if pred.dt is not null, then perform prediction
         if (!is.null(pred.dt)) {
           
-          kappa <- PredictCM(model = trained.model,
-                             dt = pred.dt,
-                             sample.df = sample.dataframe,
-                             model.type = mdl.type,
-                             return.only.kappa = only.kappa)
-          
-          auc <- PredictAUC(model = trained.model,
+          if (only.kappa) {
+            kappa <- PredictCM(model = trained.model,
+                               dt = pred.dt,
+                               sample.df = sample.dataframe,
+                               model.type = mdl.type,
+                               return.only.kappa = only.kappa)
+            
+            auc <- PredictAUC(model = trained.model,
+                              dt = pred.dt,
+                              sample.df = sample.dataframe,
+                              model.type = mdl.type)  
+            
+            return(data.frame("kappa" = kappa,
+                              "auc" = auc))
+            
+          } else {
+            
+            CM <- PredictCM(model = trained.model,
                             dt = pred.dt,
                             sample.df = sample.dataframe,
-                            model.type = mdl.type)
+                            model.type = mdl.type,
+                            return.only.kappa = only.kappa)
+            
+            return(CM)
+            
+          }
           
-          return(data.frame("kappa" = kappa,
-                            "auc" = auc))
-
         }
-
+        
       }
-
+    
     names(return.list) <- names(model.list)
-
+    
     return(return.list)
-
+    
   }
-
+  
   if (run.parallel) {  # if run.parallel is false, %dopar% in
     # ParallelPredictionFunction will run sequentially without parallel
     # backend
-
+    
     # start parallel backend
     cl <- parallel::makeCluster(2)
     doParallel::registerDoParallel(cl)
@@ -350,7 +363,7 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
                               "PredictAUC",
                               "mean_one_versus_all_AUC"))
   }
-
+  
   norm.methods <- names(train.model.list)
   model.names <- c("glmnet", "rf", "svm")
   norm.list <-
@@ -374,11 +387,11 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
                                 sample.dataframe = sample.df,
                                 mdl.type = mdl,
                                 only.kappa = only.kap)
-
+        
       }
-
+      
     }
-
+  
   if (run.parallel) {
     # stop parallel backend
     parallel::stopCluster(cl)

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -490,6 +490,16 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
 mean_one_versus_all_AUC <- function(probabilities_matrix,
                                     true_subtypes) {
   
+  # Calculate the one vs. all AUC values for each subtype and return the mean
+  #
+  # Args:
+  #   probabilities_matrix: matrix with one column per subtype, one row per
+  #     sample, and with each row summing to 1, usually the output of predict()
+  #   true_subtypes: vector of true subtype labels
+  #
+  # Returns:
+  #   AUC value (mean of one vs. all AUCs)
+  
   true_subtypes <- factor(true_subtypes)
   
   if (!all(sort(levels(true_subtypes)) == sort(colnames(probabilities_matrix)))) {
@@ -514,6 +524,20 @@ mean_one_versus_all_AUC <- function(probabilities_matrix,
 
 PredictAUC <- function(model, dt, sample.df,
                        model.type = NULL) {
+  
+  # Given a prediction model and new data, return the AUC (area under curve).
+  #
+  # Args:
+  #   model: a predictive model of the class train OR class cv.glmnet
+  #   dt: a data table where the columns are the samples and the rows are genes
+  #   sample.df: the data frame that maps sample name/header to category and
+  #              train/test set labels
+  #              output of 0-expression_data_overlap_and_split.R
+  #   model.type: is the model from glmnet (class: cv.glmnet) or from caret
+  #               class
+  #
+  # Returns:
+  #  AUC value (mean of one vs. all AUCs)
   
   category <- GetOrderedCategoryLabels(dt, sample.df)
   dt.mat <- t(dt[, -1, with = F])

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -349,14 +349,26 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
                                model.type = mdl.type,
                                return.only.kappa = only.kappa)
             
-            if (mdl.type == "glmnet" | trained.model$control$classProbs) {
-              # the model is glmnet OR if the model used classProbs = TRUE
+            if (mdl.type == "glmnet") {
+              # the model is glmnet
+              
+              auc <- PredictAUC(model = trained.model,
+                                dt = pred.dt,
+                                sample.df = sample.dataframe,
+                                model.type = mdl.type)
+              
+            } else if (trained.model$control$classProbs) {
+              # the model used classProbs = TRUE
+              
               auc <- PredictAUC(model = trained.model,
                                 dt = pred.dt,
                                 sample.df = sample.dataframe,
                                 model.type = mdl.type)  
+              
             } else { # if the model was Random Forest or SVM and used classProbs = FALSE we can't calculate AUC
+              
               auc <- NA
+              
             }
             
             return(data.frame("kappa" = kappa,
@@ -480,7 +492,7 @@ mean_one_versus_all_AUC <- function(probabilities_matrix,
   
   true_subtypes <- factor(true_subtypes)
   
-  if (sort(levels(true_subtypes)) != sort(colnames(probabilities_matrix))) {
+  if (!all(sort(levels(true_subtypes)) == sort(colnames(probabilities_matrix)))) {
     
     # if true subtypes do not match the categories with probabilities
     stop("True subtype label levels do not match predicted subtype levels in mean_one_versus_all_AUC().")

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -396,7 +396,7 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
     kappa.df <- norm.list %>%
       # when there is null test data at a particular %RNA-seq, discard that null
       purrr::modify_depth(2, function(x) discard(x, is.null)) %>%
-      reshape2::melt() %>%
+      reshape2::melt(id.vars = NULL) %>%
       tidyr::pivot_wider(names_from = "variable",
                          values_from = "value")
     colnames(kappa.df) <- c("perc.seq", "classifier", "norm.method", "kappa", "auc")

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -141,6 +141,8 @@ TrainThreeModels <- function(dt, category, seed, folds.list){
 
     fit.control <- trainControl(method = "cv",
                                 number = 5, # 5-fold cross-validation
+                                savePredictions = TRUE,
+                                classProbs = TRUE,
                                 seeds = seed.list,
                                 index = folds.list, # list of 5 sets of indices
                                 allowParallel = T) # use parallel processing
@@ -163,7 +165,7 @@ TrainThreeModels <- function(dt, category, seed, folds.list){
                                         family = "multinomial",
                                         foldid = fold.vector, # fold 'labels'
                                         parallel = T,
-                                        type.measure="class")
+                                        type.measure = "class")
     # Random Forest
     train.list[["rf"]] <- train(t_dt,
                                 category,


### PR DESCRIPTION
This purpose of this PR is adding an additional AUC metric to the kappa value we already report.

### Some background:

- We use `glmnet::cv.glmnet()` to train the lasso model. We use `caret::train()` to train the random forest and linear SVM models.
- We use `predict()` with an existing model and new data to predict subtypes. The `predict()` function works differently depending on the type of model it is given.
- The `predict()` function can return a class probabilities matrix but does so with different parameters, again depending on the type of model it is given. The format looks like:

| Subtype1 | Subtype2 | Subtype3 |
| --- | --- | --- |
| 0.07 | 0.9 | 0.03 |
| 0.8 | 0.19 | 0.01 |
| each row | sums to | 1.0 |

- For the downstream function `predict()` to return class probabilities for random forest and linear SVM models trained with `caret`, the parameter `classProbs = TRUE` should be given upstream in `caret::train()` as part of `caret::trainControl()`. Lasso models trained with `glmnet::cv.glmnet()` do not need any special parameters to predict class probabilities downstream.
- Sometimes, setting `classProbs = TRUE` creates issue with models not converging. My understanding is that `caret` does some resampling in the backend to allow class probabilities, and some models refit in that context do not converge, leading to `NA` model metrics and an `error`. For those models, resetting `classProbs = FALSE` allows the model to be fit, but we don't get to measure its AUC. I implemented this using `tryCatch()`, which first tries to train using `classProbs = TRUE`, then trains with `classProbs = FALSE` when there is an error. (In practice, this only affected some %RNA-seq settings of SVM models using GBM data with some seeds. 🤷 so they get `NA` for AUC.)

### Getting AUC

- To return a variety of model metrics, it would be nice to run `caret::multiClassSummary()`, but that did not work with the `glmnet` model.
- Instead, `MLmetrics::AUC()` works regardless of how the model was generated; it just requires a probabilities matrix and set of true subtype labels.
- `MLmetrics::AUC()` is built for binary prediction models. (We have five subtypes.)
- The AUC returned by `caret::multiClassSummary()` is the average of one vs. the rest AUC metrics calculated for each subtype.
- I wrote two new functions: `PredictAUC()` and `mean_one_versus_all_AUC` to handle finding each subtype's one vs. all AUC and then taking the unweighted mean. This approach matches the approach (and tested numerical outputs of) the AUC given by `caret::multiClassSummary()`.

### Other notes

- In creating the class probabilities matrix, each subtype gets stored in a column with the subtype as the column name. This presented an issue with the G-CIMP subtype with its special hyphen character. I fixed this upstream by turning "G-CIMP" into "GCIMP" in the raw data. Any textual reference or figure mention of that subtype will keep the hyphen.
- I did not attempt to calculate "Delta AUC", analogous to "Delta Kappa" we have for the mutation prediction results.

### Science

- The AUCs are generally high, and show less variability than Kappa values. This makes AUC less useful in determining the relative performance of each model.
- We also have unbalanced categories, which leads to another disadvantage of AUC measured as the unweighted mean of each binary one vs. all AUC. Using kappa specifically address the unbalanced categories in our data.

### Takeaway

The AUC values are now stored in a column along with kappa values for each model that will be shared as a supplementary table. For the reviewer, we can report the general trends of AUC but also point to the downsides of AUC as a measure in this project. AUC values could be plotted for the reviewer, but I don't see it getting mentioned in the manuscript or supplement. Or, we can repeat what we say to the reviewer in the manuscript... open to discussion, as always 😁 

Thank you for your review 🎉 