### PR TITLE
Envest/sens spec

### DIFF
--- a/3-combine_category_kappa.R
+++ b/3-combine_category_kappa.R
@@ -111,7 +111,7 @@ if (null_model) {
                 by = c("perc.seq", "classifier", "norm.method"),
                 suffix = c(".true", ".null")) %>%
       mutate(delta_kappa = kappa.true - kappa.null) %>% # regular kappa - null kappa
-      select(delta_kappa, auc.true, perc.seq, classifier, norm.method)
+      select(delta_kappa, auc.true, sensitivity.true, specificity.true, perc.seq, classifier, norm.method)
   }
   
 }
@@ -123,9 +123,9 @@ if (null_model) {
   seq.df <- data.table::rbindlist(delta_kappa_seq.list)
 } else {
   array.df <- data.table::rbindlist(array.list) %>%
-    select(kappa, auc, perc.seq, classifier, norm.method)
+    select(kappa, auc, sensitivity, specificity, perc.seq, classifier, norm.method)
   seq.df <- data.table::rbindlist(seq.list) %>%
-    select(kappa, auc, perc.seq, classifier, norm.method)
+    select(kappa, auc, sensitivity, specificity, perc.seq, classifier, norm.method)
 }
 
 #### save test set results -----------------------------------------------------
@@ -135,7 +135,7 @@ test.df <- cbind(rbind(array.df, seq.df),
                  c(rep("Microarray", nrow(array.df)),
                    rep("RNA-seq", nrow(seq.df))))
 
-colnames(test.df) <- c("Kappa", "AUC", "Perc.Seq", "Classifier",
+colnames(test.df) <- c("Kappa", "AUC", "Sensitivity", "Specificity", "Perc.Seq", "Classifier",
                        "Normalization", "Platform")
 
 # order %seq to display 0-100
@@ -163,6 +163,12 @@ summary.df <- test.df %>%
                    Median_AUC = median(AUC, na.rm = TRUE),
                    Mean_AUC = mean(AUC, na.rm = TRUE),
                    SD_AUC = sd(AUC, na.rm = TRUE),
+                   Median_Sensitivity = median(Sensitivity, na.rm = TRUE),
+                   Mean_Sensitivity = mean(Sensitivity, na.rm = TRUE),
+                   SD_Sensitivity = sd(Sensitivity, na.rm = TRUE),
+                   Median_Specificity = median(Specificity, na.rm = TRUE),
+                   Mean_Specificity = mean(Specificity, na.rm = TRUE),
+                   SD_Specificity = sd(Specificity, na.rm = TRUE),
                    .groups = "drop")
 
 readr::write_tsv(summary.df,

--- a/plots/scripts/3-plot_category_kappa.R
+++ b/plots/scripts/3-plot_category_kappa.R
@@ -60,7 +60,7 @@ output_filename <- file.path(output_directory,
 
 # read in data
 plot_df <- read_tsv(input_filename,
-                    col_types = "dddccc") %>%
+                    col_types = "dddddccc") %>%
   mutate(Perc.Seq = factor(Perc.Seq,
                            levels = seq(0, 100, 10)))
 

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -350,8 +350,8 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
                                return.only.kappa = FALSE)
             
             kappa <- cm$overall["Kappa"]
-            sens <- mean(x$byClass[,"Sensitivity"])
-            spec <- mean(x$byClass[,"Specificity"])
+            sens <- mean(cm$byClass[,"Sensitivity"])
+            spec <- mean(cm$byClass[,"Specificity"])
             
             if (mdl.type == "glmnet") {
               # the model is glmnet

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -343,11 +343,15 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
           
           if (only.kappa) {
             
-            kappa <- PredictCM(model = trained.model,
+            cm <- PredictCM(model = trained.model,
                                dt = pred.dt,
                                sample.df = sample.dataframe,
                                model.type = mdl.type,
-                               return.only.kappa = only.kappa)
+                               return.only.kappa = FALSE)
+            
+            kappa <- cm$overall["Kappa"]
+            sens <- mean(x$byClass[,"Sensitivity"])
+            spec <- mean(x$byClass[,"Specificity"])
             
             if (mdl.type == "glmnet") {
               # the model is glmnet
@@ -372,7 +376,9 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
             }
             
             return(data.frame("kappa" = kappa,
-                              "auc" = auc))
+                              "auc" = auc,
+                              "sens" = sens,
+                              "spec" = spec))
             
           } else {
             
@@ -460,7 +466,7 @@ PredictWrapper <- function(train.model.list, pred.list, sample.df,
       reshape2::melt(id.vars = NULL) %>%
       tidyr::pivot_wider(names_from = "variable",
                          values_from = "value")
-    colnames(kappa.df) <- c("perc.seq", "classifier", "norm.method", "kappa", "auc")
+    colnames(kappa.df) <- c("perc.seq", "classifier", "norm.method", "kappa", "auc", "sensitivity", "specificity")
     return(kappa.df)
   } else {  # otherwise, return two objects:
     # 1. the list of confusionMatrix objects (norm.list)


### PR DESCRIPTION
This PR adds in sensitivity and specificity, which probably should have gone in with AUC 😀 but alas

Just like `caret::multiClassSummary()` this will report the mean of one vs. all sensitivity and specificity. Instead of just returning kappa from the `getCM()` function, we return the whole confusion matrix, which gives access to all kappa, sensitivity, and specificity.

Thanks, again, for this review 🌮 