### PR TITLE
Check that gene column exists before setting row names

### DIFF
--- a/7-extract_plier_pathways.R
+++ b/7-extract_plier_pathways.R
@@ -98,18 +98,27 @@ convert_row_names <- function(expr, cancer_type) {
   # Inputs: gene expression matrix with genes in first column, and cancer type
   # Returns: modified gene expression matrix with gene names as row names
   
-  if (cancer_type == "GBM") {
-    expr <- expr %>%
-      mutate(gene = ensembldb::select(EnsDb.Hsapiens.v86::EnsDb.Hsapiens.v86,
-                                      keys = as.character(gene),
-                                      keytype = "GENEID",
-                                      columns = "SYMBOL"
-      )$SYMBOL)
+  if ("gene" %in% colnames(expr)) { # check that gene column exists
+    
+    if (cancer_type == "GBM") {
+      expr <- expr %>%
+        mutate(gene = ensembldb::select(EnsDb.Hsapiens.v86::EnsDb.Hsapiens.v86,
+                                        keys = as.character(gene),
+                                        keytype = "GENEID",
+                                        columns = "SYMBOL"
+        )$SYMBOL)
+    }
+    
+    column_to_rownames(expr,
+                       var = "gene"
+    )
+    
+  } else { # return NULL when no gene column exists (Seurat)
+    
+    return(NULL)
+    
   }
   
-  column_to_rownames(expr,
-                     var = "gene"
-  )
 }
 
 #### Failure of PLIER to converge may manifest in different error messages...


### PR DESCRIPTION
Before running PLIER, the gene column of an expression matrix is set to row names. Seurat data, being dimensionally reduced already, is not suitable for PLIER analysis and also has no gene column. We need to check whether that column exists (great) or set the list entry to NULL if that column does not exist.

Thanks!