### PR TITLE
Envest/svm classprobs

### DIFF
--- a/check_sums.tsv
+++ b/check_sums.tsv
@@ -9,8 +9,8 @@ ce911443e071c4251fb3f196780e76de  data/GBMClin.tsv
 e5df57691b44c47b8c916116b5ac7acf  data/PanCan-General_Open_GDC-Manifest_2.txt
 a4591b2dcee39591f59e5e25a6ce75fa  data/TCGA-CDR-SupplementalTableS1.xlsx
 7fafc537807d5b3ddf0bb89665279a9d  data/broad.mit.edu_PANCAN_Genome_Wide_SNP_6_whitelisted.seg
-2a0bae0c9bdf59687f561ed52f2ef04e  data/combined_clinical_data.BRCA.tsv
-c5197fdd1fe2163eab0ebb00ace4b55d  data/combined_clinical_data.GBM.tsv
+4c02689f22d8392bcc5f7cb4e4b4ad6b  data/combined_clinical_data.BRCA.tsv
+2d4b798f74077c40b564b5ec087f9ff9  data/combined_clinical_data.GBM.tsv
 1d8834a51282396e07e3ce9a5417d024  data/gbm_clinical_table_S7.xlsx
 639ad8f8386e98dacc22e439188aa8fa  data/mc3.v0.2.8.PUBLIC.maf.gz
 7583a5fb4d23d50b79813b26469f6385  data/mutations.BRCA.tsv

--- a/check_sums.tsv
+++ b/check_sums.tsv
@@ -9,12 +9,12 @@ ce911443e071c4251fb3f196780e76de  data/GBMClin.tsv
 e5df57691b44c47b8c916116b5ac7acf  data/PanCan-General_Open_GDC-Manifest_2.txt
 a4591b2dcee39591f59e5e25a6ce75fa  data/TCGA-CDR-SupplementalTableS1.xlsx
 7fafc537807d5b3ddf0bb89665279a9d  data/broad.mit.edu_PANCAN_Genome_Wide_SNP_6_whitelisted.seg
-d79d2399598ac2e6c11a1b44c5c603df  data/combined_clinical_data.BRCA.tsv
+2a0bae0c9bdf59687f561ed52f2ef04e  data/combined_clinical_data.BRCA.tsv
 7cd37ad1cde1c58ff76cb739bd376e5f  data/combined_clinical_data.GBM.tsv
 1d8834a51282396e07e3ce9a5417d024  data/gbm_clinical_table_S7.xlsx
 639ad8f8386e98dacc22e439188aa8fa  data/mc3.v0.2.8.PUBLIC.maf.gz
 7583a5fb4d23d50b79813b26469f6385  data/mutations.BRCA.tsv
-15cae05325c1b0562be8029efba5534a  data/mutations.GBM.tsv
+c5197fdd1fe2163eab0ebb00ace4b55d  data/mutations.GBM.tsv
 5484229fa691a721dd7fd08ade2233e7  data/mutations.maf
 e56585bd0c2e59658b1d54fc8b0c9df2  data/mutations.tsv
 b62634d9eccbb548499ce384605fe47a  data/GSE83130/LICENSE.TXT

--- a/check_sums.tsv
+++ b/check_sums.tsv
@@ -10,11 +10,11 @@ e5df57691b44c47b8c916116b5ac7acf  data/PanCan-General_Open_GDC-Manifest_2.txt
 a4591b2dcee39591f59e5e25a6ce75fa  data/TCGA-CDR-SupplementalTableS1.xlsx
 7fafc537807d5b3ddf0bb89665279a9d  data/broad.mit.edu_PANCAN_Genome_Wide_SNP_6_whitelisted.seg
 2a0bae0c9bdf59687f561ed52f2ef04e  data/combined_clinical_data.BRCA.tsv
-7cd37ad1cde1c58ff76cb739bd376e5f  data/combined_clinical_data.GBM.tsv
+c5197fdd1fe2163eab0ebb00ace4b55d  data/combined_clinical_data.GBM.tsv
 1d8834a51282396e07e3ce9a5417d024  data/gbm_clinical_table_S7.xlsx
 639ad8f8386e98dacc22e439188aa8fa  data/mc3.v0.2.8.PUBLIC.maf.gz
 7583a5fb4d23d50b79813b26469f6385  data/mutations.BRCA.tsv
-c5197fdd1fe2163eab0ebb00ace4b55d  data/mutations.GBM.tsv
+15cae05325c1b0562be8029efba5534a  data/mutations.GBM.tsv
 5484229fa691a721dd7fd08ade2233e7  data/mutations.maf
 e56585bd0c2e59658b1d54fc8b0c9df2  data/mutations.tsv
 b62634d9eccbb548499ce384605fe47a  data/GSE83130/LICENSE.TXT

--- a/combine_clinical_data.R
+++ b/combine_clinical_data.R
@@ -54,10 +54,10 @@ mutation_df <- read_tsv(mutation_input_filepath, # treat all columns equally
 combined_df <- clinical_df %>%
   left_join(mutation_df,
             by = c("Sample" = "tcga_id")) %>%
-  mutate(PIK3CA = case_when(PIK3CA == 0 ~ "No PIK3CA mutation",
-                            TRUE ~ "PIK3CA mutation"),
-         TP53 = case_when(TP53 == 0 ~ "No TP53 mutation",
-                          TRUE ~ "TP53 mutation"))
+  mutate(PIK3CA = case_when(PIK3CA == 0 ~ "No_PIK3CA_mutation",
+                            TRUE ~ "PIK3CA_mutation"),
+         TP53 = case_when(TP53 == 0 ~ "No_TP53_mutation",
+                          TRUE ~ "TP53_mutation"))
 
 ################################################################################
 # Save output file

--- a/combine_clinical_data.R
+++ b/combine_clinical_data.R
@@ -53,7 +53,11 @@ mutation_df <- read_tsv(mutation_input_filepath, # treat all columns equally
 # start join with clinical_df because later scripts expect column name = Sample
 combined_df <- clinical_df %>%
   left_join(mutation_df,
-            by = c("Sample" = "tcga_id"))
+            by = c("Sample" = "tcga_id")) %>%
+  mutate(PIK3CA = case_when(PIK3CA == 0 ~ "No PIK3CA mutation",
+                            TRUE ~ "PIK3CA mutation"),
+         TP53 = case_when(TP53 == 0 ~ "No TP53 mutation",
+                          TRUE ~ "TP53 mutation"))
 
 ################################################################################
 # Save output file

--- a/util/train_test_functions.R
+++ b/util/train_test_functions.R
@@ -182,38 +182,31 @@ TrainThreeModels <- function(dt, category, seed, folds.list){
                                                  index = folds.list, # list of 5 sets of indices
                                                  allowParallel = T) # use parallel processing
     
-    # With tryCatch, we first try to train the model using classProbs = TRUE.
-    # If it fails, we then try to train the model using classProbs = FALSE.
-    # Later, we can tell what value of classProbs succeeded with model$control$classProbs.
+    # Random Forest (works the same way with classProbs = TRUE)
+    train.list[["rf"]] <- train(t_dt,
+                                category,
+                                method = "ranger",
+                                trControl = fit.control.classProbs_TRUE,
+                                tuneLength = 3)
     
-    # Random Forest
-    train.list[["rf"]] <- tryCatch(train(t_dt,
-                                         category,
-                                         method = "ranger",
-                                         trControl = fit.control.classProbs_TRUE,
-                                         tuneLength = 3),
-                                   error = function(e) train(t_dt,
-                                                             category,
-                                                             method = "ranger",
-                                                             trControl = fit.control.classProbs_FALSE,
-                                                             tuneLength = 3))
-    # Linear SVM
-    train.list[["svm"]] <- tryCatch(train(t_dt,
-                                          category,
-                                          method = "svmLinear",
-                                          trControl = fit.control.classProbs_TRUE,
-                                          tuneLength = 3),
-                                    error = function(e) train(t_dt,
-                                                              category,
-                                                              method = "svmLinear",
-                                                              trControl = fit.control.classProbs_FALSE,
-                                                              tuneLength = 3))
+    # Linear SVM (works differently with classProbs = TRUE, so make it FALSE (default))
+    # see https://stat.ethz.ch/pipermail/r-help/2013-November/363273.html
+    train.list[["svm"]] <- train(t_dt,
+                                 category,
+                                 method = "svmLinear",
+                                 trControl = fit.control.classProbs_FALSE,
+                                 tuneLength = 3)
 
     train.list[["seeds"]] <- seed.list
+    
     return(train.list)
+    
   } else {
+    
     return(list(NULL))
+    
   }
+  
 }
 
 RestructureNormList <- function(norm.list){


### PR DESCRIPTION
Resolves #139 

There was a performance difference (worse!) when SVM models were given the `classProbs = TRUE` argument. Why? Internally, `kernlab::ksvm()` fits an additional, error prone model to estimate class probabilities. The class with highest probability from that model may not match the original SVM class prediction. When `caret::train()` sees there are class probabilities, it assumes the class with highest probability as the prediction. So we get different predictions when `classProbs = TRUE` or `FALSE`. This discrepancy can exacerbated in small and unbalanced data sets.

See: https://stat.ethz.ch/pipermail/r-help/2013-November/363273.html for some discussion of a related issue.

The main change here is to always use `classProbs = TRUE` for random forest models and `classProbs = FALSE` for SVM models. We can still get sensitivity and specificity for all models. We no longer get AUC for SVM, but SVM internal behavior is consistent for all models.

Another change is how mutation status is coded: now as a string instead of 0,1. This was quietly causing a downstream issue with AUC calculation and was not giving AUC values for the SVM and RF mutation models because of invalid column naming. This update also brings a change in the md5sum values that get checked after initial data download and processing.

Thanks! 😄 