### PR TITLE
Envest/fix mutation assignment

### DIFF
--- a/6-save_recon_error_kappa_data.R
+++ b/6-save_recon_error_kappa_data.R
@@ -42,8 +42,13 @@ rcn.res.dir <- here::here("results", "reconstructed_data")
 # define input files
 # pattern = "kappa" captures a downstream output file if this script is rerun
 # pattern = "kappa_[0-9]+.tsv" captures the intended filenames including seeds between 1:10000
-kappa.df.files <- list.files(rcn.res.dir, pattern = "kappa_[0-9]+.tsv", full.names = TRUE)
-error.files <- list.files(rcn.res.dir, pattern = paste0(file_identifier, "_reconstruction_error"),
+kappa.df.files <- list.files(rcn.res.dir,
+                             pattern = paste0(file_identifier,
+                                              "_prediction_reconstructed_data_kappa_[0-9]+.tsv"),
+                                              full.names = TRUE)
+error.files <- list.files(rcn.res.dir,
+                          pattern = paste0(file_identifier,
+                                           "_reconstruction_error"),
                           full.names = TRUE)
 
 # define output files

--- a/check_sums.tsv
+++ b/check_sums.tsv
@@ -9,8 +9,8 @@ ce911443e071c4251fb3f196780e76de  data/GBMClin.tsv
 e5df57691b44c47b8c916116b5ac7acf  data/PanCan-General_Open_GDC-Manifest_2.txt
 a4591b2dcee39591f59e5e25a6ce75fa  data/TCGA-CDR-SupplementalTableS1.xlsx
 7fafc537807d5b3ddf0bb89665279a9d  data/broad.mit.edu_PANCAN_Genome_Wide_SNP_6_whitelisted.seg
-4c02689f22d8392bcc5f7cb4e4b4ad6b  data/combined_clinical_data.BRCA.tsv
-2d4b798f74077c40b564b5ec087f9ff9  data/combined_clinical_data.GBM.tsv
+7c5f8a12d6ca986e5ebba93281360517  data/combined_clinical_data.BRCA.tsv
+94621b5396bd5d69eb36b6c5503dec97  data/combined_clinical_data.GBM.tsv
 1d8834a51282396e07e3ce9a5417d024  data/gbm_clinical_table_S7.xlsx
 639ad8f8386e98dacc22e439188aa8fa  data/mc3.v0.2.8.PUBLIC.maf.gz
 7583a5fb4d23d50b79813b26469f6385  data/mutations.BRCA.tsv

--- a/combine_clinical_data.R
+++ b/combine_clinical_data.R
@@ -55,9 +55,9 @@ combined_df <- clinical_df %>%
   left_join(mutation_df,
             by = c("Sample" = "tcga_id")) %>%
   mutate(PIK3CA = case_when(PIK3CA == 0 ~ "No_PIK3CA_mutation",
-                            TRUE ~ "PIK3CA_mutation"),
+                            PIK3CA == 1 ~ "PIK3CA_mutation"),
          TP53 = case_when(TP53 == 0 ~ "No_TP53_mutation",
-                          TRUE ~ "TP53_mutation"))
+                          TP53 == 1 ~ "TP53_mutation"))
 
 ################################################################################
 # Save output file


### PR DESCRIPTION
This PR fixes an issue silently introduced in a previous code change. This issue was that samples without mutation calls (12/520 BRCA, 4/150 GBM) were being treated as if they had the mutation. The fix resulted in no meaningful change to any mutation status prediction results, and identical results for subtype results (because nothing changed for that).

This fix:
- Updates md5sums in the `check_sums.tsv` file
- Requires mutation status be either 0 or 1, else `case_when()` returns `NA`, as originally intended

Thanks!