### PR TITLE
Envest/fix recon kappa tsv

### DIFF
--- a/6-save_recon_error_kappa_data.R
+++ b/6-save_recon_error_kappa_data.R
@@ -42,8 +42,13 @@ rcn.res.dir <- here::here("results", "reconstructed_data")
 # define input files
 # pattern = "kappa" captures a downstream output file if this script is rerun
 # pattern = "kappa_[0-9]+.tsv" captures the intended filenames including seeds between 1:10000
-kappa.df.files <- list.files(rcn.res.dir, pattern = "kappa_[0-9]+.tsv", full.names = TRUE)
-error.files <- list.files(rcn.res.dir, pattern = paste0(file_identifier, "_reconstruction_error"),
+kappa.df.files <- list.files(rcn.res.dir,
+                             pattern = paste0(file_identifier,
+                                              "_prediction_reconstructed_data_kappa_[0-9]+.tsv",
+                                              full.names = TRUE))
+error.files <- list.files(rcn.res.dir,
+                          pattern = paste0(file_identifier,
+                                           "_reconstruction_error"),
                           full.names = TRUE)
 
 # define output files

--- a/6-save_recon_error_kappa_data.R
+++ b/6-save_recon_error_kappa_data.R
@@ -44,8 +44,8 @@ rcn.res.dir <- here::here("results", "reconstructed_data")
 # pattern = "kappa_[0-9]+.tsv" captures the intended filenames including seeds between 1:10000
 kappa.df.files <- list.files(rcn.res.dir,
                              pattern = paste0(file_identifier,
-                                              "_prediction_reconstructed_data_kappa_[0-9]+.tsv",
-                                              full.names = TRUE))
+                                              "_prediction_reconstructed_data_kappa_[0-9]+.tsv"),
+                                              full.names = TRUE)
 error.files <- list.files(rcn.res.dir,
                           pattern = paste0(file_identifier,
                                            "_reconstruction_error"),


### PR DESCRIPTION
This fix came about while reviewing our Supplementary Figure 6... now that we have to show each individual data point, I noticed we had 20 data points per experimental setting in one of the cancer types, instead of 10 in both like we should expect (10 replicates).

The 20 came from `list.files()` listing any file with the form `kappa_[0-9]+.tsv`, which includes both BRCA and GBM results. The fix now includes `file_identifier` in the `list.files()` command, which is how we distinguish between `BRCA_subtype` and `GBM_subtype`, etc. results elsewhere in the repo.

I combed through other examples of `list.files()` in our code base and all the others use `file_identifier` and so do not have this problem.

One might ask... Why didn't results for BRCA and GBM look identical in Supp Fig 6? Because the first time this script is run, the only results are from one cancer type (10 results), and the second time the results are from two cancer types (20 results). 🎉 

Thank you 🙃 